### PR TITLE
minor bug in in-band registration, and vCard memory issues.

### DIFF
--- a/Extensions/XEP-0054/CoreDataStorage/XMPPvCardCoreDataStorageObject.m
+++ b/Extensions/XEP-0054/CoreDataStorage/XMPPvCardCoreDataStorageObject.m
@@ -4,6 +4,7 @@
 //
 //  Originally created by Eric Chamberlain on 3/18/11.
 //
+#import <objc/runtime.h>
 
 #import "XMPPvCardCoreDataStorageObject.h"
 #import "XMPPvCardTempCoreDataStorageObject.h"
@@ -37,7 +38,10 @@
 	
 	[fetchRequest release];
 	
-	return (XMPPvCardCoreDataStorageObject *)[results lastObject];
+	XMPPvCardCoreDataStorageObject *vCard = (XMPPvCardCoreDataStorageObject *)[results lastObject];
+	object_setClass(vCard.vCardTemp, [XMPPvCardTemp class]);
+	
+	return vCard;
 }
 
 
@@ -50,6 +54,8 @@
 	                                                                      inManagedObjectContext:moc];
 	
 	vCard.jidStr = [jid bare];
+	object_setClass(vCard.vCardTemp, [XMPPvCardTemp class]);
+	
 	return vCard;
 }
 

--- a/Extensions/XEP-0054/XMPPvCardTemp.m
+++ b/Extensions/XEP-0054/XMPPvCardTemp.m
@@ -72,24 +72,7 @@ NSString *const kXMPPvCardTempElement = @"vCard";
 
 + (XMPPvCardTemp *)vCardTempCopyFromIQ:(XMPPIQ *)iq
 {
-	// This doesn't work.
-	// It looks like the copy that comes back is of class DDXMLElement.
-	// So maybe the vCardTemp class has to implement its own copy method...
-	// 
-	//return [[[self vCardTempSubElementFromIQ:iq] copy] autorelease];
-	
-	if ([iq isResultIQ])
-	{
-		NSXMLElement *query = [iq elementForName:kXMPPvCardTempElement xmlns:kXMPPNSvCardTemp];
-		if (query)
-		{
-			NSXMLElement *queryCopy = [[query copy] autorelease];
-			
-			return [self vCardTempFromElement:queryCopy];
-		}
-	}
-	
-	return nil;
+	return [[[self vCardTempSubElementFromIQ:iq] copy] autorelease];
 }
 
 
@@ -101,6 +84,13 @@ NSString *const kXMPPvCardTempElement = @"vCard";
   return iq;
 }
 
+
+- (id)copyWithZone:(NSZone *)zone
+{
+	id theCopy = [super copyWithZone:zone];
+	object_setClass(theCopy, [XMPPvCardTemp class]);
+	return theCopy;
+}
 
 #pragma mark -
 #pragma mark Identification Types
@@ -723,7 +713,7 @@ NSString *const kXMPPvCardTempElement = @"vCard";
 
 - (void)setPhoneticSound:(NSString *)phonetic {
 	NSXMLElement *sound = [self elementForName:@"SOUND"];
-	NSXMLElement *elem;
+	NSXMLElement *elem = nil;
 	
 	if (sound == nil && phonetic != nil) {
 		sound = [NSXMLElement elementWithName:@"SOUND"];
@@ -901,7 +891,7 @@ NSString *const kXMPPvCardTempElement = @"vCard";
 
 - (void)setKeyType:(NSString *)type {
 	NSXMLElement *key = [self elementForName:@"KEY"];
-	NSXMLElement *elem;
+	NSXMLElement *elem = nil;
 	
 	if (key == nil && type != nil) {
 		key = [NSXMLElement elementWithName:@"KEY"];


### PR DESCRIPTION
2 commits:
- first is a minor update to XMPPStream to ensure it sets an error in a registration attempt.
- second is an update to fix vCard issues with incomplete class swizzling (missing object_setClass) and DDXMLNode zombie issues.  This, we believe, is related to these kind of issues:

http://code.google.com/p/xmppframework/issues/detail?id=86
