### PR TITLE
[TINY] Remove import to the disappeared XMPPFramework.h.

### DIFF
--- a/Extensions/Roster/XMPPRoster.m
+++ b/Extensions/Roster/XMPPRoster.m
@@ -1,7 +1,6 @@
 #import "XMPPRoster.h"
 #import "XMPP.h"
 #import "XMPPLogging.h"
-#import "XMPPFramework.h"
 #import "DDList.h"
 
 #if ! __has_feature(objc_arc)

--- a/Extensions/XEP-0009/XMPPJabberRPCModule.m
+++ b/Extensions/XEP-0009/XMPPJabberRPCModule.m
@@ -10,7 +10,6 @@
 #import "XMPPIQ+JabberRPC.h"
 #import "XMPPIQ+JabberRPCResonse.h"
 #import "XMPPLogging.h"
-#import "XMPPFramework.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).

--- a/Extensions/XEP-0045/XMPPMUC.m
+++ b/Extensions/XEP-0045/XMPPMUC.m
@@ -1,5 +1,4 @@
 #import "XMPPMUC.h"
-#import "XMPPFramework.h"
 
 
 @implementation XMPPMUC

--- a/Extensions/XEP-0060/XMPPPubSub.m
+++ b/Extensions/XEP-0060/XMPPPubSub.m
@@ -5,7 +5,7 @@
 //
 
 #import "XMPPPubSub.h"
-#import "XMPPFramework.h"
+#import "XMPP.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).

--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -1,5 +1,4 @@
 #import "XMPPMessageArchiving.h"
-#import "XMPPFramework.h"
 #import "XMPPLogging.h"
 #import "NSNumber+XMPP.h"
 

--- a/Extensions/XEP-0199/XMPPPing.m
+++ b/Extensions/XEP-0199/XMPPPing.m
@@ -1,6 +1,5 @@
 #import "XMPPPing.h"
 #import "XMPPIDTracker.h"
-#import "XMPPFramework.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).

--- a/Extensions/XEP-0202/XMPPTime.m
+++ b/Extensions/XEP-0202/XMPPTime.m
@@ -1,7 +1,6 @@
 #import "XMPPTime.h"
 #import "XMPPIDTracker.h"
 #import "XMPPDateTimeProfiles.h"
-#import "XMPPFramework.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).


### PR DESCRIPTION
Many extensions import `XMPPFramework.h`, but they don't really need it.

The commit removes those references (or changes it to the `XMPP.h`) while the projects still compile (tested including the extensions I modified in the iPhone and Mac sample).

I “needed” this change, since in the project I was using XMPPFramework there wasn’t a `XMPPFramework.h` (we use a different name), but the include path happens to add `XMPPFramework/Xcode` folder recursively. This actually imports a `XMPPFramework.h` from the examples, which has `XMPPCapabilites.h` included, which we don’t use in the real project. A dummy `XMPPFramework.h` will work as a workaround, but we think that the framework files should not depend on a “consumer” provided header.
