### PR TITLE
XEP-0153 additions for XMPPPresence

### DIFF
--- a/Extensions/XEP-0153/XMPPPresence+XEP_0153.h
+++ b/Extensions/XEP-0153/XMPPPresence+XEP_0153.h
@@ -1,12 +1,11 @@
 //
 //  XMPPPresence+XEP_0153.h
-//  FlamingoXMPP
 //
 //  Created by Indragie Karunaratne on 2013-01-08.
 //  Copyright (c) 2013 Indragie Karunaratne. All rights reserved.
 //
 
-#import <FlamingoXMPP/FlamingoXMPP.h>
+#import "XMPPPresence.h"
 
 @interface XMPPPresence (XEP_0153)
 // SHA1 hash of the photo data for the handle that sent this presence

--- a/Extensions/XEP-0153/XMPPPresence+XEP_0153.m
+++ b/Extensions/XEP-0153/XMPPPresence+XEP_0153.m
@@ -1,12 +1,12 @@
 //
 //  XMPPPresence+XEP_0153.m
-//  FlamingoXMPP
 //
 //  Created by Indragie Karunaratne on 2013-01-08.
 //  Copyright (c) 2013 Indragie Karunaratne. All rights reserved.
 //
 
 #import "XMPPPresence+XEP_0153.h"
+#import "NSXMLElement+XMPP.h"
 
 static NSString* const XMPPPresenceElementX = @"x";
 static NSString* const XMPPPresenceElementNSX = @"vcard-temp:x:update";


### PR DESCRIPTION
Adds a `photoHash` property with the SHA1 photo hash from the `vcard-temp:x:update` element of the presence, as documented in XEP-0153.
