### PR TITLE
Fix DDList removeAll: not moving to the next node after removing the first.

### DIFF
--- a/Utilities/DDList.m
+++ b/Utilities/DDList.m
@@ -64,6 +64,7 @@
 	DDListNode *node = listHead;
 	while (node != NULL)
 	{
+		DDListNode *nextNode = node->next;
 		if (element == node->element)
 		{
 			// Remove the node from the list.
@@ -90,10 +91,7 @@
 			
 			if (!allInstances) break;
 		}
-		else
-		{
-			node = node->next;
-		}
+		node = nextNode;
 	}
 }
 

--- a/Xcode/Testing/TestDDList/TestDDList/AppDelegate.m
+++ b/Xcode/Testing/TestDDList/TestDDList/AppDelegate.m
@@ -72,11 +72,26 @@
 	NSLog(@"%@: Done", NSStringFromSelector(_cmd));
 }
 
+- (void)testRemoveAllWithOneElement
+{
+	NSLog(@"%@: Start", NSStringFromSelector(_cmd));
+
+	NSString *theElement = @"theElement";
+	DDList *list = [[DDList alloc] init];
+
+	[list add:(__bridge void *)theElement];
+
+	[list removeAll:(__bridge void *)theElement];
+
+	NSLog(@"%@: Done", NSStringFromSelector(_cmd));
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
 	[self testZeroElements];
 	[self testOneElement];
 	[self testMultipleElements];
+	[self testRemoveAllWithOneElement];
 }
 
 @end


### PR DESCRIPTION
`-[DDList remove:allInstances:]` includes a bug when invoked with `allInstances:YES` (as it is from `-[DDList removeAll:]`). The current implementation doesn’t advance to the next node in the list, iterating over the same node over and over, and freeing that node each time, which will cause a crash during runtime.
