### PR TITLE
Remove all uses of dispatch_get_current_queue, except for logging.

### DIFF
--- a/Authentication/Anonymous/XMPPAnonymousAuthentication.m
+++ b/Authentication/Anonymous/XMPPAnonymousAuthentication.m
@@ -116,8 +116,9 @@
 			result = NO;
 		}
 	}};
-	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);

--- a/Authentication/Deprecated-Digest/XMPPDeprecatedDigestAuthentication.m
+++ b/Authentication/Deprecated-Digest/XMPPDeprecatedDigestAuthentication.m
@@ -150,8 +150,9 @@
 			result = (digest != nil);
 		}
 	}};
-	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);

--- a/Authentication/Deprecated-Plain/XMPPDeprecatedPlainAuthentication.m
+++ b/Authentication/Deprecated-Plain/XMPPDeprecatedPlainAuthentication.m
@@ -144,8 +144,9 @@
 			result = (plain != nil);
 		}
 	}};
-	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);

--- a/Authentication/X-Facebook-Platform/XMPPXFacebookPlatformAuthentication.m
+++ b/Authentication/X-Facebook-Platform/XMPPXFacebookPlatformAuthentication.m
@@ -252,8 +252,9 @@ static char facebookAppIdKey;
 	dispatch_block_t block = ^{
 		result = objc_getAssociatedObject(self, &facebookAppIdKey);
 	};
-	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);
@@ -269,7 +270,8 @@ static char facebookAppIdKey;
 		objc_setAssociatedObject(self, &facebookAppIdKey, newFacebookAppId, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 	};
 	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(self.xmppQueue, block);
@@ -313,8 +315,8 @@ static char facebookAppIdKey;
 		}
 	}};
 	
-	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);

--- a/Core/XMPPInternal.h
+++ b/Core/XMPPInternal.h
@@ -45,6 +45,7 @@ extern NSString *const XMPPStreamDidChangeMyJIDNotification;
 **/
 
 @property (readonly) dispatch_queue_t xmppQueue;
+@property (readonly) const char *xmppQueueTag;
 @property (readonly) XMPPStreamState state;
 
 /**

--- a/Core/XMPPModule.h
+++ b/Core/XMPPModule.h
@@ -16,8 +16,9 @@
 @interface XMPPModule : NSObject
 {
 	XMPPStream *xmppStream;
-	
+
 	dispatch_queue_t moduleQueue;
+	const char* moduleQueueTag;
 	id multicastDelegate;
 }
 

--- a/Core/XMPPModule.m
+++ b/Core/XMPPModule.m
@@ -39,7 +39,6 @@
   static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
 #endif
 
-
 @implementation XMPPModule
 
 /**
@@ -57,6 +56,7 @@
 {
 	if ((self = [super init]))
 	{
+		moduleQueueTag = "moduleQueueTag";
 		if (queue)
 		{
 			moduleQueue = queue;
@@ -69,6 +69,7 @@
 			const char *moduleQueueName = [[self moduleName] UTF8String];
 			moduleQueue = dispatch_queue_create(moduleQueueName, NULL);
 		}
+		dispatch_queue_set_specific(moduleQueue, moduleQueueTag, (void *)moduleQueueTag, NULL);
 		
 		multicastDelegate = [[GCDMulticastDelegate alloc] init];
 	}
@@ -106,7 +107,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -135,7 +136,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -148,7 +149,7 @@
 
 - (XMPPStream *)xmppStream
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return xmppStream;
 	}
@@ -172,7 +173,7 @@
 		[multicastDelegate addDelegate:delegate delegateQueue:delegateQueue];
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -184,7 +185,7 @@
 		[multicastDelegate removeDelegate:delegate delegateQueue:delegateQueue];
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else if (synchronously)
 		dispatch_sync(moduleQueue, block);

--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -97,6 +97,7 @@ enum XMPPStreamConfig
 @interface XMPPStream ()
 {
 	dispatch_queue_t xmppQueue;
+	const char *xmppQueueTag;
 	
 	dispatch_queue_t willSendIqQueue;
 	dispatch_queue_t willSendMessageQueue;
@@ -193,7 +194,9 @@ enum XMPPStreamConfig
 **/
 - (void)commonInit
 {
+	xmppQueueTag = "xmppQueueTag";
 	xmppQueue = dispatch_queue_create("xmpp", NULL);
+	dispatch_queue_set_specific(xmppQueue, xmppQueueTag, (void *)xmppQueueTag, NULL);
 	
 	willSendIqQueue = dispatch_queue_create("xmpp.willSendIq", NULL);
 	willSendMessageQueue = dispatch_queue_create("xmpp.willSendMessage", NULL);
@@ -314,6 +317,7 @@ enum XMPPStreamConfig
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @synthesize xmppQueue;
+@synthesize xmppQueueTag;
 
 - (XMPPStreamState)state
 {
@@ -323,7 +327,7 @@ enum XMPPStreamConfig
 		result = (XMPPStreamState)state;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -333,7 +337,7 @@ enum XMPPStreamConfig
 
 - (NSString *)hostName
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return hostName;
 	}
@@ -351,7 +355,7 @@ enum XMPPStreamConfig
 
 - (void)setHostName:(NSString *)newHostName
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		if (hostName != newHostName)
 		{
@@ -371,7 +375,7 @@ enum XMPPStreamConfig
 
 - (UInt16)hostPort
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return hostPort;
 	}
@@ -393,7 +397,7 @@ enum XMPPStreamConfig
 		hostPort = newHostPort;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -411,7 +415,7 @@ enum XMPPStreamConfig
 			result = myJID_setByClient;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -437,7 +441,7 @@ enum XMPPStreamConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -467,7 +471,7 @@ enum XMPPStreamConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -480,7 +484,7 @@ enum XMPPStreamConfig
 
 - (XMPPJID *)remoteJID
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return remoteJID;
 	}
@@ -498,7 +502,7 @@ enum XMPPStreamConfig
 
 - (XMPPPresence *)myPresence
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return myPresence;
 	}
@@ -522,7 +526,7 @@ enum XMPPStreamConfig
 		result = keepAliveInterval;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -545,7 +549,7 @@ enum XMPPStreamConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -564,7 +568,7 @@ enum XMPPStreamConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -582,7 +586,7 @@ enum XMPPStreamConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -590,7 +594,7 @@ enum XMPPStreamConfig
 
 - (UInt64)numberOfBytesSent
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return numberOfBytesSent;
 	}
@@ -608,7 +612,7 @@ enum XMPPStreamConfig
 
 - (UInt64)numberOfBytesReceived
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return numberOfBytesReceived;
 	}
@@ -632,7 +636,7 @@ enum XMPPStreamConfig
 		result = (config & kResetByteCountPerConnection) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -649,7 +653,7 @@ enum XMPPStreamConfig
 			config &= ~kResetByteCountPerConnection;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -665,7 +669,7 @@ enum XMPPStreamConfig
 		result = (config & kEnableBackgroundingOnSocket) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -682,7 +686,7 @@ enum XMPPStreamConfig
 			config &= ~kEnableBackgroundingOnSocket;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -702,7 +706,7 @@ enum XMPPStreamConfig
 		[multicastDelegate addDelegate:delegate delegateQueue:delegateQueue];
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -716,7 +720,7 @@ enum XMPPStreamConfig
 		[multicastDelegate removeDelegate:delegate delegateQueue:delegateQueue];
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -730,7 +734,7 @@ enum XMPPStreamConfig
 		[multicastDelegate removeDelegate:delegate];
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -742,7 +746,7 @@ enum XMPPStreamConfig
 **/
 - (BOOL)isP2P
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return (config & kP2PMode) ? YES : NO;
 	}
@@ -760,7 +764,7 @@ enum XMPPStreamConfig
 
 - (BOOL)isP2PInitiator
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return ((config & kP2PMode) && (flags & kP2PInitiator));
 	}
@@ -778,7 +782,7 @@ enum XMPPStreamConfig
 
 - (BOOL)isP2PRecipient
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return ((config & kP2PMode) && !(flags & kP2PInitiator));
 	}
@@ -796,14 +800,14 @@ enum XMPPStreamConfig
 
 - (BOOL)didStartNegotiation
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	return (flags & kDidStartNegotiation) ? YES : NO;
 }
 
 - (void)setDidStartNegotiation:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	if (flag)
 		flags |= kDidStartNegotiation;
@@ -827,7 +831,7 @@ enum XMPPStreamConfig
 		result = (state == STATE_XMPP_DISCONNECTED);
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -847,7 +851,7 @@ enum XMPPStreamConfig
 		result = (state == STATE_XMPP_CONNECTED);
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -861,7 +865,7 @@ enum XMPPStreamConfig
 
 - (BOOL)connectToHost:(NSString *)host onPort:(UInt16)port error:(NSError **)errPtr
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -969,7 +973,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1006,7 +1010,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1091,7 +1095,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1176,7 +1180,7 @@ enum XMPPStreamConfig
 		[self startNegotiation];
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1222,7 +1226,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1263,7 +1267,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -1278,7 +1282,7 @@ enum XMPPStreamConfig
 **/
 - (BOOL)isSecure
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return (flags & kIsSecure) ? YES : NO;
 	}
@@ -1303,7 +1307,7 @@ enum XMPPStreamConfig
 			flags &= ~kIsSecure;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -1326,7 +1330,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1336,7 +1340,7 @@ enum XMPPStreamConfig
 
 - (void)sendStartTLSRequest
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1406,7 +1410,7 @@ enum XMPPStreamConfig
 		
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1442,7 +1446,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1523,7 +1527,7 @@ enum XMPPStreamConfig
 		
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1561,7 +1565,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1602,7 +1606,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1659,7 +1663,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1751,7 +1755,7 @@ enum XMPPStreamConfig
 	}};
 	
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1770,7 +1774,7 @@ enum XMPPStreamConfig
 		result = (flags & kIsAuthenticated) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -1787,7 +1791,7 @@ enum XMPPStreamConfig
 			flags &= ~kIsAuthenticated;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -1807,7 +1811,7 @@ enum XMPPStreamConfig
 **/
 - (NSXMLElement *)rootElement
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return rootElement;
 	}
@@ -1830,7 +1834,7 @@ enum XMPPStreamConfig
 **/
 - (float)serverXmppStreamVersionNumber
 {
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 	{
 		return [rootElement attributeFloatValueForName:@"version" withDefaultValue:0.0F];
 	}
@@ -1848,7 +1852,7 @@ enum XMPPStreamConfig
 
 - (void)sendIQ:(XMPPIQ *)iq withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	// We're getting ready to send an IQ.
@@ -1918,7 +1922,7 @@ enum XMPPStreamConfig
 
 - (void)sendMessage:(XMPPMessage *)message withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	// We're getting ready to send a message.
@@ -1988,7 +1992,7 @@ enum XMPPStreamConfig
 
 - (void)sendPresence:(XMPPPresence *)presence withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	// We're getting ready to send a presence element.
@@ -2058,7 +2062,7 @@ enum XMPPStreamConfig
 
 - (void)continueSendIQ:(XMPPIQ *)iq withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	NSString *outgoingStr = [iq compactXMLString];
@@ -2076,7 +2080,7 @@ enum XMPPStreamConfig
 
 - (void)continueSendMessage:(XMPPMessage *)message withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	NSString *outgoingStr = [message compactXMLString];
@@ -2094,7 +2098,7 @@ enum XMPPStreamConfig
 
 - (void)continueSendPresence:(XMPPPresence *)presence withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	NSString *outgoingStr = [presence compactXMLString];
@@ -2127,7 +2131,7 @@ enum XMPPStreamConfig
 
 - (void)continueSendElement:(NSXMLElement *)element withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	NSString *outgoingStr = [element compactXMLString];
@@ -2147,7 +2151,7 @@ enum XMPPStreamConfig
 **/
 - (void)sendElement:(NSXMLElement *)element withTag:(long)tag
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	
 	if ([element isKindOfClass:[XMPPIQ class]])
@@ -2201,7 +2205,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -2237,7 +2241,7 @@ enum XMPPStreamConfig
 			}
 		}};
 		
-		if (dispatch_get_current_queue() == xmppQueue)
+		if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 			block();
 		else
 			dispatch_sync(xmppQueue, block);
@@ -2260,7 +2264,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -2293,7 +2297,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -2301,7 +2305,7 @@ enum XMPPStreamConfig
 
 - (void)receiveIQ:(XMPPIQ *)iq
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	// We're getting ready to receive an IQ.
@@ -2356,7 +2360,7 @@ enum XMPPStreamConfig
 
 - (void)receiveMessage:(XMPPMessage *)message
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	// We're getting ready to receive a message.
@@ -2411,7 +2415,7 @@ enum XMPPStreamConfig
 
 - (void)receivePresence:(XMPPPresence *)presence
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(state == STATE_XMPP_CONNECTED, @"Invoked with incorrect state");
 	
 	// We're getting ready to receive a presence element.
@@ -2624,7 +2628,7 @@ enum XMPPStreamConfig
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -2639,7 +2643,7 @@ enum XMPPStreamConfig
 **/
 - (void)startNegotiation
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	NSAssert(![self didStartNegotiation], @"Invoked after initial negotiation has started");
 	
 	XMPPLogTrace();
@@ -2659,7 +2663,7 @@ enum XMPPStreamConfig
 **/
 - (void)sendOpeningNegotiation
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -2759,7 +2763,7 @@ enum XMPPStreamConfig
 **/
 - (void)startTLS
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -2814,7 +2818,7 @@ enum XMPPStreamConfig
 
 - (void)continueStartTLS:(NSMutableDictionary *)settings
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace2(@"%@: %@ %@", THIS_FILE, THIS_METHOD, settings);
 	
@@ -2866,7 +2870,7 @@ enum XMPPStreamConfig
 **/
 - (void)handleStreamFeatures
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -2972,7 +2976,7 @@ enum XMPPStreamConfig
 
 - (void)handleStartTLSResponse:(NSXMLElement *)response
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -2997,7 +3001,7 @@ enum XMPPStreamConfig
 **/
 - (void)handleRegistration:(NSXMLElement *)response
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -3029,7 +3033,7 @@ enum XMPPStreamConfig
 **/
 - (void)handleAuth:(NSXMLElement *)authResponse
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -3102,7 +3106,7 @@ enum XMPPStreamConfig
 
 - (void)handleBinding:(NSXMLElement *)response
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -3276,7 +3280,7 @@ enum XMPPStreamConfig
 
 - (void)handleStartSessionResponse:(NSXMLElement *)response
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -3302,7 +3306,7 @@ enum XMPPStreamConfig
 
 - (void)tryNextSrvResult
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -3350,7 +3354,7 @@ enum XMPPStreamConfig
 
 - (void)srvResolver:(XMPPSRVResolver *)sender didResolveRecords:(NSArray *)records
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	if (sender != srvResolver) return;
 	
@@ -3366,7 +3370,7 @@ enum XMPPStreamConfig
 
 - (void)srvResolver:(XMPPSRVResolver *)sender didNotResolveDueToError:(NSError *)error
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	if (sender != srvResolver) return;
 	
@@ -3797,7 +3801,7 @@ enum XMPPStreamConfig
 
 - (void)setupKeepAliveTimer
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -3844,7 +3848,7 @@ enum XMPPStreamConfig
 
 - (void)keepAlive
 {
-	NSAssert(dispatch_get_current_queue() == xmppQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(xmppQueueTag) == xmppQueueTag, @"Invoked on incorrect queue");
 	
 	if (state == STATE_XMPP_CONNECTED)
 	{
@@ -3907,7 +3911,7 @@ enum XMPPStreamConfig
 	
 	// Asynchronous operation
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -3952,7 +3956,7 @@ enum XMPPStreamConfig
 	
 	// Synchronous operation
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -3996,7 +4000,7 @@ enum XMPPStreamConfig
 	
 	// Asynchronous operation
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_async(xmppQueue, block);
@@ -4059,7 +4063,7 @@ enum XMPPStreamConfig
 	
 	// Synchronous operation
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -4087,7 +4091,7 @@ enum XMPPStreamConfig
 	
 	// Synchronous operation
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);
@@ -4132,7 +4136,7 @@ enum XMPPStreamConfig
 		result = xmppUtilityRunLoop;
 	};
 	
-	if (dispatch_get_current_queue() == xmppQueue)
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(xmppQueue, block);

--- a/Extensions/BandwidthMonitor/XMPPBandwidthMonitor.m
+++ b/Extensions/BandwidthMonitor/XMPPBandwidthMonitor.m
@@ -33,7 +33,7 @@
 		result = smoothedAverageOutgoingBandwidth;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -49,7 +49,7 @@
 		result = smoothedAverageIncomingBandwidth;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -132,7 +132,9 @@
 		smoothedAverageIncomingBandwidth = 0.0;
 		
 		dispatch_source_cancel(timer);
+		#if !OS_OBJECT_USE_OBJC
 		dispatch_release(timer);
+		#endif
 		timer = NULL;
 	}
 }
@@ -159,7 +161,7 @@
 		[super deactivate];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);

--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.h
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.h
@@ -56,6 +56,7 @@
 	NSUInteger saveCount;
 	
 	dispatch_queue_t storageQueue;
+	const char *storageQueueTag;
 }
 
 /**

--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
@@ -250,7 +250,9 @@ static NSMutableSet *databaseFileNames;
 - (void)commonInit
 {
 	saveThreshold = 500;
+	storageQueueTag = "storageQueueTag";
 	storageQueue = dispatch_queue_create(class_getName([self class]), NULL);
+	dispatch_queue_set_specific(storageQueue, storageQueueTag, (void *)storageQueueTag, NULL);
 	
 	myJidCache = [[NSMutableDictionary alloc] init];
 	
@@ -319,7 +321,7 @@ static NSMutableSet *databaseFileNames;
 
 - (NSUInteger)saveThreshold
 {
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 	{
 		return saveThreshold;
 	}
@@ -341,7 +343,7 @@ static NSMutableSet *databaseFileNames;
 		saveThreshold = newSaveThreshold;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -382,7 +384,7 @@ static NSMutableSet *databaseFileNames;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -429,7 +431,7 @@ static NSMutableSet *databaseFileNames;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -509,7 +511,7 @@ static NSMutableSet *databaseFileNames;
 		result = managedObjectModel;
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -583,7 +585,7 @@ static NSMutableSet *databaseFileNames;
 		
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -609,7 +611,7 @@ static NSMutableSet *databaseFileNames;
 	// then you need to go read the documentation for core data,
 	// specifically the section entitled "Concurrency with Core Data".
 	// 
-	NSAssert(dispatch_get_current_queue() == storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	// 
 	// Do NOT remove the assert statment above!
 	// Read the comments above!
@@ -654,7 +656,7 @@ static NSMutableSet *databaseFileNames;
 	// then you need to go read the documentation for core data,
 	// specifically the section entitled "Concurrency with Core Data".
 	// 
-	NSAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"Context reserved for main thread only");
+	NSAssert([NSThread isMainThread], @"Context reserved for main thread only");
 	// 
 	// Do NOT remove the assert statment above!
 	// Read the comments above!
@@ -749,7 +751,7 @@ static NSMutableSet *databaseFileNames;
 
 - (void)maybeSave:(int32_t)currentPendingRequests
 {
-	NSAssert(dispatch_get_current_queue() == storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	
 	if ([[self managedObjectContext] hasChanges])
@@ -787,7 +789,7 @@ static NSMutableSet *databaseFileNames;
 	// If you remove the assert statement below, you are destroying the sole purpose for this class,
 	// which is to optimize the disk IO by buffering save operations.
 	// 
-	NSAssert(dispatch_get_current_queue() != storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	// 
 	// For a full discussion of this method, please see XMPPCoreDataStorageProtocol.h
 	//
@@ -817,7 +819,7 @@ static NSMutableSet *databaseFileNames;
 	// If you remove the assert statement below, you are destroying the sole purpose for this class,
 	// which is to optimize the disk IO by buffering save operations.
 	// 
-	NSAssert(dispatch_get_current_queue() != storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	// 
 	// For a full discussion of this method, please see XMPPCoreDataStorageProtocol.h
 	// 

--- a/Extensions/ProcessOne/XMPPProcessOne.m
+++ b/Extensions/ProcessOne/XMPPProcessOne.m
@@ -93,7 +93,7 @@ NSString *const XMPPProcessOneSessionDate = @"XMPPProcessOneSessionDate";
 
 - (NSXMLElement *)pushConfiguration
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return pushConfiguration;
 	}
@@ -130,7 +130,7 @@ NSString *const XMPPProcessOneSessionDate = @"XMPPProcessOneSessionDate";
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -384,8 +384,9 @@ NSString *const XMPPProcessOneSessionDate = @"XMPPProcessOneSessionDate";
 			result = (push != nil);
 		}
 	}};
-	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);
@@ -410,7 +411,8 @@ NSString *const XMPPProcessOneSessionDate = @"XMPPProcessOneSessionDate";
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == self.xmppQueue)
+	const char *xmppQueueTag = self.xmppQueueTag;
+	if (dispatch_get_specific(xmppQueueTag) == xmppQueueTag)
 		block();
 	else
 		dispatch_sync(self.xmppQueue, block);

--- a/Extensions/Reconnect/XMPPReconnect.m
+++ b/Extensions/Reconnect/XMPPReconnect.m
@@ -113,7 +113,7 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 		[self teardownNetworkMonitoring];
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -132,7 +132,7 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 		result = (config & kAutoReconnect) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -149,7 +149,7 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 			config &= ~kAutoReconnect;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -157,14 +157,14 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 
 - (BOOL)shouldReconnect
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	return (flags & kShouldReconnect) ? YES : NO;
 }
 
 - (void)setShouldReconnect:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	if (flag)
 		flags |= kShouldReconnect;
@@ -174,14 +174,14 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 
 - (BOOL)multipleReachabilityChanges
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	return (flags & kMultipleChanges) ? YES : NO;
 }
 
 - (void)setMultipleReachabilityChanges:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	if (flag)
 		flags |= kMultipleChanges;
@@ -191,14 +191,14 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 
 - (BOOL)manuallyStarted
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	return (flags & kManuallyStarted) ? YES : NO;
 }
 
 - (void)setManuallyStarted:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	if (flag)
 		flags |= kManuallyStarted;
@@ -208,14 +208,14 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 
 - (BOOL)queryingDelegates
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	return (flags & kQueryingDelegates) ? YES : NO;
 }
 
 - (void)setQueryingDelegates:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked private method outside moduleQueue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked private method outside moduleQueue");
 	
 	if (flag)
 		flags |= kQueryingDelegates;
@@ -240,7 +240,7 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -263,7 +263,7 @@ typedef SCNetworkConnectionFlags SCNetworkReachabilityFlags;
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -394,7 +394,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)setupReconnectTimer
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (reconnectTimer == NULL)
 	{
@@ -440,7 +440,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)teardownReconnectTimer
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (reconnectTimer)
 	{
@@ -451,7 +451,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)setupNetworkMonitoring
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (reachability == NULL)
 	{
@@ -483,7 +483,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)teardownNetworkMonitoring
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (reachability)
 	{
@@ -513,7 +513,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 **/
 - (void)maybeAttemptReconnect
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (reachability)
 	{
@@ -531,7 +531,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 **/
 - (void)maybeAttemptReconnectWithTicket:(int)ticket
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (ticket != reconnectTicket)
 	{
@@ -551,7 +551,7 @@ static void ReachabilityChanged(SCNetworkReachabilityRef target, SCNetworkReacha
 
 - (void)maybeAttemptReconnectWithReachabilityFlags:(SCNetworkReachabilityFlags)reachabilityFlags
 {
-	if (dispatch_get_current_queue() != moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		dispatch_async(moduleQueue, ^{ @autoreleasepool {
 			

--- a/Extensions/Roster/CoreDataStorage/XMPPRosterCoreDataStorage.m
+++ b/Extensions/Roster/CoreDataStorage/XMPPRosterCoreDataStorage.m
@@ -20,7 +20,7 @@
 #endif
 
 #define AssertPrivateQueue() \
-        NSAssert(dispatch_get_current_queue() == storageQueue, @"Private method: MUST run on storageQueue");
+        NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Private method: MUST run on storageQueue");
 
 
 @implementation XMPPRosterCoreDataStorage

--- a/Extensions/Roster/MemoryStorage/XMPPRosterMemoryStorage.h
+++ b/Extensions/Roster/MemoryStorage/XMPPRosterMemoryStorage.h
@@ -19,6 +19,7 @@
 	__unsafe_unretained XMPPRoster *parent;
   #endif	
 	dispatch_queue_t parentQueue;
+	const char *parentQueueTag;
 	
 	Class userClass;
 	Class resourceClass;

--- a/Extensions/Roster/MemoryStorage/XMPPRosterMemoryStorage.m
+++ b/Extensions/Roster/MemoryStorage/XMPPRosterMemoryStorage.m
@@ -42,10 +42,10 @@
 #endif
 
 #define AssertPrivateQueue() \
-        NSAssert(dispatch_get_current_queue() == parentQueue, @"Private method: MUST run on parentQueue");
+        NSAssert(dispatch_get_specific(parentQueueTag) == parentQueueTag, @"Private method: MUST run on parentQueue");
 
 #define AssertParentQueue() \
-        NSAssert(dispatch_get_current_queue() == parentQueue, @"Private protocol method: MUST run on parentQueue");
+        NSAssert(dispatch_get_specific(parentQueueTag) == parentQueueTag, @"Private protocol method: MUST run on parentQueue");
 
 @interface XMPPRosterMemoryStorage ()
 
@@ -81,7 +81,9 @@
 		if ((parent == nil) && (parentQueue == NULL))
 		{
 			parent = aParent;
+			parentQueueTag = "parentQueueTag";
 			parentQueue = queue;
+			dispatch_queue_set_specific(parentQueue, parentQueueTag, (void *)parentQueueTag, NULL);
 			
 			#if NEEDS_DISPATCH_RETAIN_RELEASE
 			dispatch_retain(parentQueue);
@@ -294,7 +296,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return myUser;
 	}
@@ -320,7 +322,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return (XMPPResourceMemoryStorageObject *)[myUser resourceForJID:myJID];
 	}
@@ -348,7 +350,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _userForJID:jid];
 	}
@@ -377,7 +379,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _resourceForJID:jid];
 	}
@@ -406,7 +408,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _sortedUsersByName];
 	}
@@ -436,7 +438,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _sortedUsersByAvailabilityName];
 	}
@@ -466,7 +468,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _sortedAvailableUsersByName];
 	}
@@ -495,7 +497,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _sortedUnavailableUsersByName];
 	}
@@ -524,7 +526,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _unsortedUsers];
 	}
@@ -553,7 +555,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _unsortedAvailableUsers];
 	}
@@ -582,7 +584,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _unsortedUnavailableUsers];
 	}
@@ -611,7 +613,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [self _sortedResources:includeResourcesForMyUserExcludingMyself];
 	}

--- a/Extensions/Roster/XMPPRoster.m
+++ b/Extensions/Roster/XMPPRoster.m
@@ -163,7 +163,7 @@ enum XMPPRosterFlags
 		result = (config & kAutoFetchRoster) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -181,7 +181,7 @@ enum XMPPRosterFlags
 			config &= ~kAutoFetchRoster;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -195,7 +195,7 @@ enum XMPPRosterFlags
 		result = (config & kAutoAcceptKnownPresenceSubscriptionRequests) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -213,7 +213,7 @@ enum XMPPRosterFlags
 			config &= ~kAutoAcceptKnownPresenceSubscriptionRequests;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -227,7 +227,7 @@ enum XMPPRosterFlags
 		result = (config & kRosterlessOperation) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -245,7 +245,7 @@ enum XMPPRosterFlags
 			config &= ~kRosterlessOperation;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -257,14 +257,14 @@ enum XMPPRosterFlags
 
 - (BOOL)requestedRoster
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	return (flags & kRequestedRoster) ? YES : NO;
 }
 
 - (void)setRequestedRoster:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (flag)
 		flags |= kRequestedRoster;
@@ -274,14 +274,14 @@ enum XMPPRosterFlags
 
 - (BOOL)hasRoster
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	return (flags & kHasRoster) ? YES : NO;
 }
 
 - (void)setHasRoster:(BOOL)flag
 {
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	if (flag)
 		flags |= kHasRoster;
@@ -565,7 +565,7 @@ enum XMPPRosterFlags
 		[self setRequestedRoster:YES];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0009/XMPPJabberRPCModule.m
+++ b/Extensions/XEP-0009/XMPPJabberRPCModule.m
@@ -136,7 +136,7 @@ NSString *const XMPPJabberRPCErrorDomain = @"XMPPJabberRPCErrorDomain";
 		result = defaultTimeout;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -151,7 +151,7 @@ NSString *const XMPPJabberRPCErrorDomain = @"XMPPJabberRPCErrorDomain";
 		defaultTimeout = newDefaultTimeout;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0016/XMPPPrivacy.m
+++ b/Extensions/XEP-0016/XMPPPrivacy.m
@@ -115,7 +115,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 
 - (BOOL)autoRetrievePrivacyListNames
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return autoRetrievePrivacyListNames;
 	}
@@ -138,7 +138,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 		autoRetrievePrivacyListNames = flag;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -146,7 +146,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 
 - (BOOL)autoRetrievePrivacyListItems
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return autoRetrievePrivacyListItems;
 	}
@@ -169,7 +169,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 		autoRetrievePrivacyListItems = flag;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -177,7 +177,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 
 - (BOOL)autoClearPrivacyListInfo
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return autoClearPrivacyListInfo;
 	}
@@ -200,7 +200,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 		autoClearPrivacyListInfo = flag;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -260,7 +260,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 {
 	XMPPLogTrace();
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		[privacyDict removeAllObjects];
 	}
@@ -275,7 +275,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 
 - (NSArray *)listNames
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return [privacyDict allKeys];
 	}
@@ -307,7 +307,7 @@ typedef enum XMPPPrivacyQueryInfoType {
 	// ExecuteVoidBlock(moduleQueue, block);
 	// ExecuteNonVoidBlock(moduleQueue, block, NSArray*)
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return block();
 	}

--- a/Extensions/XEP-0045/CoreDataStorage/XMPPRoomCoreDataStorage.m
+++ b/Extensions/XEP-0045/CoreDataStorage/XMPPRoomCoreDataStorage.m
@@ -41,7 +41,7 @@
 #endif
 
 #define AssertPrivateQueue() \
-            NSAssert(dispatch_get_current_queue() == storageQueue, @"Private method: MUST run on storageQueue");
+            NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Private method: MUST run on storageQueue");
 
 @interface XMPPRoomCoreDataStorage ()
 {
@@ -130,7 +130,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		result = messageEntityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -144,7 +144,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		messageEntityName = newMessageEntityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -158,7 +158,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		result = occupantEntityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -172,7 +172,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		occupantEntityName = newOccupantEntityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -186,7 +186,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		result = maxMessageAge;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -254,7 +254,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -268,7 +268,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		result = deleteInterval;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -325,7 +325,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -338,7 +338,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		[pausedMessageDeletion addObject:[roomJID bareJID]];
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -352,7 +352,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 		[self performDelete];
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);

--- a/Extensions/XEP-0045/HybridStorage/XMPPRoomHybridStorage.m
+++ b/Extensions/XEP-0045/HybridStorage/XMPPRoomHybridStorage.m
@@ -42,7 +42,7 @@
 #endif
 
 #define AssertPrivateQueue() \
-            NSAssert(dispatch_get_current_queue() == storageQueue, @"Private method: MUST run on storageQueue");
+            NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Private method: MUST run on storageQueue");
 
 
 @interface XMPPRoomHybridStorage ()
@@ -177,7 +177,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		result = maxMessageAge;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -245,7 +245,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -259,7 +259,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		result = deleteInterval;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -316,7 +316,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -329,7 +329,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		[pausedMessageDeletion addObject:[roomJID bareJID]];
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -343,7 +343,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		[self performDelete];
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -833,7 +833,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block(NO);
 	else
 		dispatch_sync(storageQueue, ^{ block(YES); });
@@ -880,7 +880,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block(NO);
 	else
 		dispatch_sync(storageQueue, ^{ block(YES); });

--- a/Extensions/XEP-0045/MemoryStorage/XMPPRoomMemoryStorage.m
+++ b/Extensions/XEP-0045/MemoryStorage/XMPPRoomMemoryStorage.m
@@ -42,10 +42,10 @@
 #endif
 
 #define AssertPrivateQueue() \
-        NSAssert(dispatch_get_current_queue() == parentQueue, @"Private method: MUST run on parentQueue");
+        NSAssert(dispatch_get_specific(parentQueueTag) == parentQueueTag, @"Private method: MUST run on parentQueue");
 
 #define AssertParentQueue() \
-        NSAssert(dispatch_get_current_queue() == parentQueue, @"Private protocol method: MUST run on parentQueue");
+        NSAssert(dispatch_get_specific(parentQueueTag) == parentQueueTag, @"Private protocol method: MUST run on parentQueue");
 
 @interface XMPPRoomMemoryStorage ()
 {
@@ -55,6 +55,7 @@
 	__unsafe_unretained XMPPRoom *parent;
   #endif
 	dispatch_queue_t parentQueue;
+	const char *parentQueueTag;
 	
 	NSMutableArray * messages;
 	NSMutableArray * occupantsArray;
@@ -100,7 +101,9 @@
 		if ((parent == nil) && (parentQueue == NULL))
 		{
 			parent = aParent;
+			parentQueueTag = "parentQueueTag";
 			parentQueue = queue;
+			dispatch_queue_set_specific(parentQueue, parentQueueTag, (void *)parentQueueTag, NULL);
 			
 			#if NEEDS_DISPATCH_RETAIN_RELEASE
 			dispatch_retain(parentQueue);
@@ -468,7 +471,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return [occupantsDict objectForKey:jid];
 	}
@@ -495,7 +498,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return messages;
 	}
@@ -522,7 +525,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		return occupantsArray;
 	}
@@ -549,7 +552,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		[messages sortUsingSelector:@selector(compare:)];
 		return messages;
@@ -578,7 +581,7 @@
 		return nil;
 	}
 	
-	if (dispatch_get_current_queue() == parentQueue)
+	if (dispatch_get_specific(parentQueueTag) == parentQueueTag)
 	{
 		[occupantsArray sortUsingSelector:@selector(compare:)];
 		return occupantsArray;

--- a/Extensions/XEP-0045/XMPPMUC.m
+++ b/Extensions/XEP-0045/XMPPMUC.m
@@ -55,7 +55,7 @@
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);

--- a/Extensions/XEP-0045/XMPPRoom.m
+++ b/Extensions/XEP-0045/XMPPRoom.m
@@ -104,7 +104,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -150,7 +150,7 @@ enum XMPPRoomState
 
 - (XMPPJID *)myRoomJID
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return myRoomJID;
 	}
@@ -168,7 +168,7 @@ enum XMPPRoomState
 
 - (NSString *)myNickname
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return myNickname;
 	}
@@ -186,7 +186,7 @@ enum XMPPRoomState
 
 - (NSString *)roomSubject
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return roomSubject;
 	}
@@ -210,7 +210,7 @@ enum XMPPRoomState
 		result = (state & kXMPPRoomStateJoined) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -229,7 +229,7 @@ enum XMPPRoomState
 		result = [myOccupant.affiliation isEqualToString:@"owner"];
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -301,7 +301,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -373,7 +373,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -471,7 +471,7 @@ enum XMPPRoomState
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -544,7 +544,7 @@ enum XMPPRoomState
 		              timeout:60.0];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -605,7 +605,7 @@ enum XMPPRoomState
 		              timeout:60.0];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -667,7 +667,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -719,7 +719,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -751,7 +751,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -801,7 +801,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -846,7 +846,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -875,7 +875,7 @@ enum XMPPRoomState
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0054/XMPPvCardTempModule.m
+++ b/Extensions/XEP-0054/XMPPvCardTempModule.m
@@ -130,7 +130,7 @@
 		result = vCardTemp;
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -173,7 +173,7 @@
 		                                                                  forJID:jid];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0065/TURNSocket.h
+++ b/Extensions/XEP-0065/TURNSocket.h
@@ -17,6 +17,7 @@
 	BOOL isClient;
 	
 	dispatch_queue_t turnQueue;
+	const char *turnQueueTag;
 	
 	XMPPStream *xmppStream;
 	XMPPJID *jid;

--- a/Extensions/XEP-0065/TURNSocket.m
+++ b/Extensions/XEP-0065/TURNSocket.m
@@ -282,8 +282,10 @@ static NSMutableArray *proxyCandidates;
 {
 	// Create dispatch queue.
 	
+	turnQueueTag = "turnQueueTag";
 	turnQueue = dispatch_queue_create("TURNSocket", NULL);
-	
+	dispatch_queue_set_specific(turnQueue, turnQueueTag, (void *)turnQueueTag, NULL);
+
 	// We want to add this new turn socket to the list of existing sockets.
 	// This gives us a central repository of turn socket objects that we can easily query.
 	
@@ -430,7 +432,7 @@ static NSMutableArray *proxyCandidates;
 		}
 	}};
 	
-	if (dispatch_get_current_queue() == turnQueue)
+	if (dispatch_get_specific(turnQueueTag) == turnQueueTag)
 		block();
 	else
 		dispatch_async(turnQueue, block);
@@ -1343,7 +1345,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)setupDiscoTimer:(NSTimeInterval)timeout
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	if (discoTimer == NULL)
 	{
@@ -1406,7 +1408,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)doDiscoItemsTimeout:(NSString *)theUUID
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	if (state == STATE_PROXY_DISCO_ITEMS)
 	{
@@ -1422,7 +1424,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)doDiscoInfoTimeout:(NSString *)theUUID
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	if (state == STATE_PROXY_DISCO_INFO)
 	{
@@ -1438,7 +1440,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)doDiscoAddressTimeout:(NSString *)theUUID
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	if (state == STATE_PROXY_DISCO_ADDR)
 	{
@@ -1455,7 +1457,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)doTotalTimeout
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	if ((state != STATE_DONE) && (state != STATE_FAILURE))
 	{
@@ -1475,7 +1477,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)succeed
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1498,7 +1500,7 @@ static NSMutableArray *proxyCandidates;
 
 - (void)fail
 {
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1523,7 +1525,7 @@ static NSMutableArray *proxyCandidates;
 - (void)cleanup
 {
 	// This method must be run on the turnQueue
-	NSAssert(dispatch_get_current_queue() == turnQueue, @"Invoked on incorrect queue.");
+	NSAssert(dispatch_get_specific(turnQueueTag) == turnQueueTag, @"Invoked on incorrect queue.");
 	
 	XMPPLogTrace();
 	

--- a/Extensions/XEP-0115/CoreDataStorage/XMPPCapabilitiesCoreDataStorage.m
+++ b/Extensions/XEP-0115/CoreDataStorage/XMPPCapabilitiesCoreDataStorage.m
@@ -46,7 +46,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (XMPPCapsResourceCoreDataStorageObject *)resourceForJID:(XMPPJID *)jid xmppStream:(XMPPStream *)stream
 {
-	NSAssert(dispatch_get_current_queue() == storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace2(@"%@: %@ %@", THIS_FILE, THIS_METHOD, jid);
 	
@@ -77,7 +77,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (XMPPCapsCoreDataStorageObject *)capsForHash:(NSString *)hash algorithm:(NSString *)hashAlg
 {
-	NSAssert(dispatch_get_current_queue() == storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace2(@"%@: capsForHash:%@ algorithm:%@", THIS_FILE, hash, hashAlg);
 	
@@ -105,7 +105,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (void)_clearAllNonPersistentCapabilitiesForXMPPStream:(XMPPStream *)stream
 {
-	NSAssert(dispatch_get_current_queue() == storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	NSEntityDescription *entity = [NSEntityDescription entityForName:@"XMPPCapsResourceCoreDataStorageObject"
 	                                          inManagedObjectContext:[self managedObjectContext]];
@@ -220,7 +220,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 - (NSXMLElement *)capabilitiesForJID:(XMPPJID *)jid ext:(NSString **)extPtr xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(dispatch_get_current_queue() != storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -331,7 +331,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
                  xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(dispatch_get_current_queue() != storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -411,7 +411,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
                   xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(dispatch_get_current_queue() != storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -519,7 +519,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 - (void)setCapabilities:(NSXMLElement *)capabilities forJID:(XMPPJID *)jid xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(dispatch_get_current_queue() != storageQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(storageQueueTag) == storageQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	

--- a/Extensions/XEP-0115/XMPPCapabilities.m
+++ b/Extensions/XEP-0115/XMPPCapabilities.m
@@ -221,7 +221,7 @@
 		result = autoFetchHashedCapabilities;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -235,7 +235,7 @@
 		autoFetchHashedCapabilities = flag;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -249,7 +249,7 @@
 		result = autoFetchNonHashedCapabilities;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -263,7 +263,7 @@
 		autoFetchNonHashedCapabilities = flag;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -655,7 +655,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)collectMyCapabilities
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -734,7 +734,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)continueCollectMyCapabilities:(NSXMLElement *)query
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -790,7 +790,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 		[self collectMyCapabilities];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -924,7 +924,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -937,7 +937,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)handlePresenceCapabilities:(NSXMLElement *)c fromJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace2(@"%@: %@ %@", THIS_FILE, THIS_METHOD, jid);
 	
@@ -1069,7 +1069,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)handleLegacyPresenceCapabilities:(NSXMLElement *)c fromJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace2(@"%@: %@ %@", THIS_FILE, THIS_METHOD, jid);
 	
@@ -1140,7 +1140,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)handleDiscoRequest:(XMPPIQ *)iqRequest
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1184,7 +1184,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)handleDiscoResponse:(NSXMLElement *)querySubElement fromJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1274,7 +1274,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)handleDiscoErrorResponse:(NSXMLElement *)querySubElement fromJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1309,7 +1309,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)maybeQueryNextJidWithHashKey:(NSString *)key dueToHashMismatch:(BOOL)hashMismatch
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1557,7 +1557,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)setupTimeoutForDiscoRequestFromJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1593,7 +1593,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)setupTimeoutForDiscoRequestFromJID:(XMPPJID *)jid withHashKey:(NSString *)key
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1629,7 +1629,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)cancelTimeoutForDiscoRequestFromJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1644,7 +1644,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)processTimeoutWithHashKey:(NSString *)key
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -1654,7 +1654,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 - (void)processTimeoutWithJID:(XMPPJID *)jid
 {
 	// This method must be invoked on the moduleQueue
-	NSAssert(dispatch_get_current_queue() == moduleQueue, @"Invoked on incorrect queue");
+	NSAssert(dispatch_get_specific(moduleQueueTag) == moduleQueueTag, @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -257,7 +257,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 		result = messageEntityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -271,7 +271,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 		messageEntityName = entityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);
@@ -285,7 +285,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 		result = contactEntityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_sync(storageQueue, block);
@@ -299,7 +299,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 		contactEntityName = entityName;
 	};
 	
-	if (dispatch_get_current_queue() == storageQueue)
+	if (dispatch_get_specific(storageQueueTag) == storageQueueTag)
 		block();
 	else
 		dispatch_async(storageQueue, block);

--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -105,7 +105,7 @@
 		result = clientSideMessageArchivingOnly;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -119,7 +119,7 @@
 		clientSideMessageArchivingOnly = flag;
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -134,7 +134,7 @@
 		result = [preferences copy];
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -164,7 +164,7 @@
 		//  - Send new pref to server (if changed)
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0153/XMPPvCardAvatarModule.m
+++ b/Extensions/XEP-0153/XMPPvCardAvatarModule.m
@@ -127,7 +127,7 @@ NSString *const kXMPPvCardAvatarPhotoElement = @"photo";
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);

--- a/Extensions/XEP-0199/XMPPAutoPing.m
+++ b/Extensions/XEP-0199/XMPPAutoPing.m
@@ -99,7 +99,7 @@
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -120,7 +120,7 @@
 
 - (NSTimeInterval)pingInterval
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return pingInterval;
 	}
@@ -161,7 +161,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -169,7 +169,7 @@
 
 - (NSTimeInterval)pingTimeout
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return pingTimeout;
 	}
@@ -194,7 +194,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -202,7 +202,7 @@
 
 - (XMPPJID *)targetJID
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return targetJID;
 	}
@@ -229,7 +229,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -237,7 +237,7 @@
 
 - (NSTimeInterval)lastReceiveTime
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return lastReceiveTime;
 	}

--- a/Extensions/XEP-0199/XMPPPing.m
+++ b/Extensions/XEP-0199/XMPPPing.m
@@ -73,7 +73,7 @@
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -84,7 +84,7 @@
 
 - (BOOL)respondsToQueries
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return respondsToQueries;
 	}
@@ -116,7 +116,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0202/XMPPAutoTime.m
+++ b/Extensions/XEP-0202/XMPPAutoTime.m
@@ -104,7 +104,7 @@
 		[super deactivate];
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -127,7 +127,7 @@
 
 - (NSTimeInterval)recalibrationInterval
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return recalibrationInterval;
 	}
@@ -168,7 +168,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -176,7 +176,7 @@
 
 - (XMPPJID *)targetJID
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return targetJID;
 	}
@@ -201,7 +201,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);
@@ -209,7 +209,7 @@
 
 - (NSTimeInterval)timeDifference
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return timeDifference;
 	}
@@ -227,7 +227,7 @@
 
 - (dispatch_time_t)lastCalibrationTime
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return lastCalibrationTime;
 	}

--- a/Extensions/XEP-0202/XMPPTime.m
+++ b/Extensions/XEP-0202/XMPPTime.m
@@ -73,7 +73,7 @@
 		
 	}};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_sync(moduleQueue, block);
@@ -84,7 +84,7 @@
 
 - (BOOL)respondsToQueries
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return respondsToQueries;
 	}
@@ -116,7 +116,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0224/XMPPAttentionModule.m
+++ b/Extensions/XEP-0224/XMPPAttentionModule.m
@@ -44,7 +44,7 @@
 
 - (BOOL)respondsToQueries
 {
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 	{
 		return respondsToQueries;
 	}
@@ -76,7 +76,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == moduleQueue)
+	if (dispatch_get_specific(moduleQueueTag) == moduleQueueTag)
 		block();
 	else
 		dispatch_async(moduleQueue, block);

--- a/Extensions/XEP-0224/XMPPMessage+XEP_0224.m
+++ b/Extensions/XEP-0224/XMPPMessage+XEP_0224.m
@@ -1,5 +1,7 @@
 #import "XMPPMessage+XEP_0224.h"
 
+#import "NSXMLElement+XMPP.h"
+
 @implementation XMPPMessage (XEP_0224)
 
 - (BOOL)isHeadLineMessage {

--- a/Utilities/XMPPIDTracker.m
+++ b/Utilities/XMPPIDTracker.m
@@ -30,11 +30,18 @@
 
 #endif
 
-#define AssertProperQueue() NSAssert(dispatch_get_current_queue() == queue, @"Invoked on incorrect queue")
+#define AssertProperQueue() NSAssert(dispatch_get_specific(queueTag) == queueTag, @"Invoked on incorrect queue")
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@interface XMPPIDTracker ()
+{
+	const char *queueTag;
+}
+
+@end
 
 @implementation XMPPIDTracker
 
@@ -51,7 +58,9 @@
 	
 	if ((self = [super init]))
 	{
+		queueTag = "queueTag";
 		queue = aQueue;
+		dispatch_queue_set_specific(queue, queueTag, (void *)queueTag, NULL);
 		#if NEEDS_DISPATCH_RETAIN_RELEASE
 		dispatch_retain(queue);
 		#endif

--- a/Utilities/XMPPSRVResolver.h
+++ b/Utilities/XMPPSRVResolver.h
@@ -17,6 +17,7 @@ extern NSString *const XMPPSRVResolverErrorDomain;
 	dispatch_queue_t delegateQueue;
 	
 	dispatch_queue_t resolverQueue;
+	const char *resolverQueueTag;
 	
 	__strong NSString *srvName;
 	NSTimeInterval timeout;

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
@@ -112,6 +112,7 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 	NSData * connectInterface6;
 	
 	dispatch_queue_t socketQueue;
+	const char *socketQueueTag;
 	
 	dispatch_source_t accept4Source;
 	dispatch_source_t accept6Source;

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
@@ -1007,7 +1007,8 @@ enum GCDAsyncSocketConfig
 		socket4FD = SOCKET_NULL;
 		socket6FD = SOCKET_NULL;
 		connectIndex = 0;
-		
+
+		socketQueueTag = "socketQueueTag";
 		if (sq)
 		{
 			NSAssert(sq != dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),
@@ -1026,6 +1027,7 @@ enum GCDAsyncSocketConfig
 		{
 			socketQueue = dispatch_queue_create([GCDAsyncSocketQueueName UTF8String], NULL);
 		}
+		dispatch_queue_set_specific(socketQueue, socketQueueTag, (void *)socketQueueTag, NULL);
 		
 		readQueue = [[NSMutableArray alloc] initWithCapacity:5];
 		currentRead = nil;
@@ -1042,7 +1044,7 @@ enum GCDAsyncSocketConfig
 {
 	LogInfo(@"%@ - %@ (start)", THIS_METHOD, self);
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		[self closeWithError:nil];
 	}
@@ -1074,7 +1076,7 @@ enum GCDAsyncSocketConfig
 
 - (id)delegate
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return delegate;
 	}
@@ -1096,7 +1098,7 @@ enum GCDAsyncSocketConfig
 		delegate = newDelegate;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue) {
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag) {
 		block();
 	}
 	else {
@@ -1119,7 +1121,7 @@ enum GCDAsyncSocketConfig
 
 - (dispatch_queue_t)delegateQueue
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return delegateQueue;
 	}
@@ -1147,7 +1149,7 @@ enum GCDAsyncSocketConfig
 		delegateQueue = newDelegateQueue;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue) {
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag) {
 		block();
 	}
 	else {
@@ -1170,7 +1172,7 @@ enum GCDAsyncSocketConfig
 
 - (void)getDelegate:(id *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		if (delegatePtr) *delegatePtr = delegate;
 		if (delegateQueuePtr) *delegateQueuePtr = delegateQueue;
@@ -1204,7 +1206,7 @@ enum GCDAsyncSocketConfig
 		delegateQueue = newDelegateQueue;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue) {
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag) {
 		block();
 	}
 	else {
@@ -1229,7 +1231,7 @@ enum GCDAsyncSocketConfig
 {
 	// Note: YES means kAllowHalfDuplexConnection is OFF
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return ((config & kAllowHalfDuplexConnection) == 0);
 	}
@@ -1257,7 +1259,7 @@ enum GCDAsyncSocketConfig
 			config |= kAllowHalfDuplexConnection;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_async(socketQueue, block);
@@ -1267,7 +1269,7 @@ enum GCDAsyncSocketConfig
 {
 	// Note: YES means kIPv4Disabled is OFF
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return ((config & kIPv4Disabled) == 0);
 	}
@@ -1295,7 +1297,7 @@ enum GCDAsyncSocketConfig
 			config |= kIPv4Disabled;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_async(socketQueue, block);
@@ -1305,7 +1307,7 @@ enum GCDAsyncSocketConfig
 {
 	// Note: YES means kIPv6Disabled is OFF
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return ((config & kIPv6Disabled) == 0);
 	}
@@ -1333,7 +1335,7 @@ enum GCDAsyncSocketConfig
 			config |= kIPv6Disabled;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_async(socketQueue, block);
@@ -1343,7 +1345,7 @@ enum GCDAsyncSocketConfig
 {
 	// Note: YES means kPreferIPv6 is OFF
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return ((config & kPreferIPv6) == 0);
 	}
@@ -1371,7 +1373,7 @@ enum GCDAsyncSocketConfig
 			config |= kPreferIPv6;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_async(socketQueue, block);
@@ -1386,7 +1388,7 @@ enum GCDAsyncSocketConfig
 		result = userData;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -1404,7 +1406,7 @@ enum GCDAsyncSocketConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_async(socketQueue, block);
@@ -1692,7 +1694,7 @@ enum GCDAsyncSocketConfig
 		result = YES;
 	}};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -1834,7 +1836,7 @@ enum GCDAsyncSocketConfig
 **/
 - (BOOL)preConnectWithInterface:(NSString *)interface error:(NSError **)errPtr
 {
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	if (delegate == nil) // Must have delegate set
 	{
@@ -1999,7 +2001,7 @@ enum GCDAsyncSocketConfig
 		result = YES;
 	}};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -2113,7 +2115,7 @@ enum GCDAsyncSocketConfig
 		result = YES;
 	}};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -2226,7 +2228,7 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	NSAssert(address4 || address6, @"Expected at least one valid address");
 	
 	if (aConnectIndex != connectIndex)
@@ -2280,7 +2282,7 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	
 	if (aConnectIndex != connectIndex)
@@ -2300,7 +2302,7 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	LogVerbose(@"IPv4: %@:%hu", [[self class] hostFromAddress:address4], [[self class] portFromAddress:address4]);
 	LogVerbose(@"IPv6: %@:%hu", [[self class] hostFromAddress:address6], [[self class] portFromAddress:address6]);
@@ -2413,7 +2415,7 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	
 	if (aConnectIndex != connectIndex)
@@ -2540,7 +2542,7 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	
 	if (aConnectIndex != connectIndex)
@@ -2625,7 +2627,7 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	
 	[self endConnectTimeout];
@@ -2789,7 +2791,7 @@ enum GCDAsyncSocketConfig
 	
 	// Synchronous disconnection, as documented in the header file
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -2838,7 +2840,7 @@ enum GCDAsyncSocketConfig
 **/
 - (void)maybeClose
 {
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	BOOL shouldClose = NO;
 	
@@ -3007,7 +3009,7 @@ enum GCDAsyncSocketConfig
 		result = (flags & kSocketStarted) ? NO : YES;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -3023,7 +3025,7 @@ enum GCDAsyncSocketConfig
 		result = (flags & kConnected) ? YES : NO;
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -3033,7 +3035,7 @@ enum GCDAsyncSocketConfig
 
 - (NSString *)connectedHost
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		if (socket4FD != SOCKET_NULL)
 			return [self connectedHostFromSocket4:socket4FD];
@@ -3060,7 +3062,7 @@ enum GCDAsyncSocketConfig
 
 - (uint16_t)connectedPort
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		if (socket4FD != SOCKET_NULL)
 			return [self connectedPortFromSocket4:socket4FD];
@@ -3088,7 +3090,7 @@ enum GCDAsyncSocketConfig
 
 - (NSString *)localHost
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		if (socket4FD != SOCKET_NULL)
 			return [self localHostFromSocket4:socket4FD];
@@ -3115,7 +3117,7 @@ enum GCDAsyncSocketConfig
 
 - (uint16_t)localPort
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		if (socket4FD != SOCKET_NULL)
 			return [self localPortFromSocket4:socket4FD];
@@ -3329,7 +3331,7 @@ enum GCDAsyncSocketConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -3365,7 +3367,7 @@ enum GCDAsyncSocketConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -3375,7 +3377,7 @@ enum GCDAsyncSocketConfig
 
 - (BOOL)isIPv4
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return (socket4FD != SOCKET_NULL);
 	}
@@ -3393,7 +3395,7 @@ enum GCDAsyncSocketConfig
 
 - (BOOL)isIPv6
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return (socket6FD != SOCKET_NULL);
 	}
@@ -3411,7 +3413,7 @@ enum GCDAsyncSocketConfig
 
 - (BOOL)isSecure
 {
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 	{
 		return (flags & kSocketSecure) ? YES : NO;
 	}
@@ -3949,7 +3951,7 @@ enum GCDAsyncSocketConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -3970,7 +3972,7 @@ enum GCDAsyncSocketConfig
 - (void)maybeDequeueRead
 {
 	LogTrace();
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	// If we're not currently processing a read AND we have an available read stream
 	if ((currentRead == nil) && (flags & kConnected))
@@ -5197,7 +5199,7 @@ enum GCDAsyncSocketConfig
 		}
 	};
 	
-	if (dispatch_get_current_queue() == socketQueue)
+	if (dispatch_get_specific(socketQueueTag) == socketQueueTag)
 		block();
 	else
 		dispatch_sync(socketQueue, block);
@@ -5218,7 +5220,7 @@ enum GCDAsyncSocketConfig
 - (void)maybeDequeueWrite
 {
 	LogTrace();
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	
 	// If we're not currently processing a write AND we have an available write stream
@@ -6093,7 +6095,7 @@ static OSStatus SSLReadFunction(SSLConnectionRef connection, void *data, size_t 
 {
 	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
 	
-	NSCAssert(dispatch_get_current_queue() == asyncSocket->socketQueue, @"What the deuce?");
+	NSCAssert(dispatch_get_specific(asyncSocket->socketQueueTag) == asyncSocket->socketQueueTag, @"What the deuce?");
 	
 	return [asyncSocket sslReadWithBuffer:data length:dataLength];
 }
@@ -6102,7 +6104,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 {
 	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
 	
-	NSCAssert(dispatch_get_current_queue() == asyncSocket->socketQueue, @"What the deuce?");
+	NSCAssert(dispatch_get_specific(asyncSocket->socketQueueTag) == asyncSocket->socketQueueTag, @"What the deuce?");
 	
 	return [asyncSocket sslWriteWithBuffer:data length:dataLength];
 }
@@ -6874,7 +6876,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	
 	
 	if (readStream || writeStream)
@@ -6936,7 +6938,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 {
 	LogVerbose(@"%@ %@", THIS_METHOD, (includeReadWrite ? @"YES" : @"NO"));
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
 	
 	streamContext.version = 0;
@@ -6970,7 +6972,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
 	
 	if (!(flags & kAddedStreamsToRunLoop))
@@ -6993,7 +6995,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
 	
 	if (flags & kAddedStreamsToRunLoop)
@@ -7013,7 +7015,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 {
 	LogTrace();
 	
-	NSAssert(dispatch_get_current_queue() == socketQueue, @"Must be dispatched on socketQueue");
+	NSAssert(dispatch_get_specific(socketQueueTag) == socketQueueTag, @"Must be dispatched on socketQueue");
 	NSAssert((readStream != NULL && writeStream != NULL), @"Read/Write stream is null");
 	
 	CFStreamStatus readStatus = CFReadStreamGetStatus(readStream);
@@ -7049,7 +7051,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 - (int)socketFD
 {
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return SOCKET_NULL;
@@ -7063,7 +7065,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 - (int)socket4FD
 {
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return SOCKET_NULL;
@@ -7074,7 +7076,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 - (int)socket6FD
 {
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return SOCKET_NULL;
@@ -7087,7 +7089,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 - (CFReadStreamRef)readStream
 {
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return NULL;
@@ -7101,7 +7103,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 - (CFWriteStreamRef)writeStream
 {
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return NULL;
@@ -7148,7 +7150,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 {
 	LogTrace();
 	
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return NO;
@@ -7165,7 +7167,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 	
 	LogTrace();
 	
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return NO;
@@ -7178,7 +7180,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 - (SSLContextRef)sslContext
 {
-	if (dispatch_get_current_queue() != socketQueue)
+	if (dispatch_get_specific(socketQueueTag) != socketQueueTag)
 	{
 		LogWarn(@"%@ - Method only available from within the context of a performBlock: invocation", THIS_METHOD);
 		return NULL;

--- a/Vendor/CocoaLumberjack/DDAbstractDatabaseLogger.m
+++ b/Vendor/CocoaLumberjack/DDAbstractDatabaseLogger.m
@@ -239,7 +239,7 @@
 
 - (NSUInteger)saveThreshold
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return saveThreshold;
 	}
@@ -279,7 +279,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -287,7 +287,7 @@
 
 - (NSTimeInterval)saveInterval
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return saveInterval;
 	}
@@ -362,7 +362,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -370,7 +370,7 @@
 
 - (NSTimeInterval)maxAge
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return maxAge;
 	}
@@ -451,7 +451,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -459,7 +459,7 @@
 
 - (NSTimeInterval)deleteInterval
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return deleteInterval;
 	}
@@ -533,7 +533,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -541,7 +541,7 @@
 
 - (BOOL)deleteOnEverySave
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return deleteOnEverySave;
 	}
@@ -564,7 +564,7 @@
 		deleteOnEverySave = flag;
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -581,7 +581,7 @@
 		[self performSaveAndSuspendSaveTimer];
 	}};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -594,7 +594,7 @@
 		[self performDelete];
 	}};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 		block();
 	else
 		dispatch_async(loggerQueue, block);

--- a/Vendor/CocoaLumberjack/DDFileLogger.m
+++ b/Vendor/CocoaLumberjack/DDFileLogger.m
@@ -528,15 +528,15 @@
 	// Note: The internal implementation should access the maximumFileSize variable directly,
 	// but if we forget to do this, then this method should at least work properly.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return maximumFileSize;
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
 		
 		__block unsigned long long result;
 		
@@ -562,16 +562,16 @@
 		
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -586,16 +586,16 @@
 	// Note: The internal implementation should access the rollingFrequency variable directly,
 	// but if we forget to do this, then this method should at least work properly.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return rollingFrequency;
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		__block NSTimeInterval result;
 		
 		dispatch_sync(globalLoggingQueue, ^{
@@ -620,16 +620,16 @@
 		
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -700,15 +700,15 @@
 		[self rollLogFileNow];
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
 		
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);

--- a/Vendor/CocoaLumberjack/DDLog.h
+++ b/Vendor/CocoaLumberjack/DDLog.h
@@ -271,8 +271,16 @@ NSString *DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  * Provides access to the underlying logging queue.
  * This may be helpful to Logger classes for things like thread synchronization.
 **/
-
 + (dispatch_queue_t)loggingQueue;
+
+/**
+ * Provides access to the queue specific that identifies the loggingQueue.
+ *
+ * Use it as the following:
+ *     const char *tag = [DDLog loggingQueueTag];
+ *     NSAssert(dispatch_get_specific(tag) == tag, @"Ouch");
+**/
++ (const char *)loggingQueueTag;
 
 /**
  * Logging Primitive.
@@ -589,6 +597,7 @@ typedef int DDLogMessageOptions;
 	id <DDLogFormatter> formatter;
 	
 	dispatch_queue_t loggerQueue;
+	const char *loggerQueueTag;
 }
 
 - (id <DDLogFormatter>)logFormatter;

--- a/Vendor/CocoaLumberjack/DDTTYLogger.m
+++ b/Vendor/CocoaLumberjack/DDTTYLogger.m
@@ -873,16 +873,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of this method is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		return colorsEnabled;
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		__block BOOL result;
 		
 		dispatch_sync(globalLoggingQueue, ^{
@@ -909,16 +909,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -962,16 +962,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -998,16 +998,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -1043,16 +1043,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -1071,16 +1071,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -1097,16 +1097,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});
@@ -1123,15 +1123,15 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
 		
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
@@ -1150,16 +1150,16 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
-	if (currentQueue == loggerQueue)
+	if (dispatch_get_specific(loggerQueueTag) == loggerQueueTag)
 	{
 		block();
 	}
 	else
 	{
 		dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
-		NSAssert(currentQueue != globalLoggingQueue, @"Core architecture requirement failure");
-		
+		const char *globalLoggingQueueTag = [DDLog loggingQueueTag];
+		NSAssert(dispatch_get_specific(globalLoggingQueueTag) != globalLoggingQueueTag, @"Core architecture requirement failure");
+
 		dispatch_async(globalLoggingQueue, ^{
 			dispatch_async(loggerQueue, block);
 		});

--- a/Xcode/Testing/MulticastDelegateTest/Shared/DelegateTesters.m
+++ b/Xcode/Testing/MulticastDelegateTest/Shared/DelegateTesters.m
@@ -1,6 +1,12 @@
 #import "DelegateTesters.h"
 
-#define dispatch_current_queue_label() dispatch_queue_get_label(dispatch_get_current_queue())
+#define dispatch_current_queue_label() ({                                     \
+	_Pragma("clang diagnostic push");                                           \
+	_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"");          \
+	const char *label = dispatch_queue_get_label(dispatch_get_current_queue()); \
+	_Pragma("clang diagnostic pop");                                            \
+	label;                                                                      \
+})
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -

--- a/Xcode/Testing/MulticastDelegateTest/Shared/MulticastDelegateTest.m
+++ b/Xcode/Testing/MulticastDelegateTest/Shared/MulticastDelegateTest.m
@@ -124,10 +124,12 @@ static MulticastDelegateTest *sharedInstance;
 		
 		// If the semaphore has been signaled, then dispatch_semaphore_wait will return zero.
 		result = (dispatch_semaphore_wait(semaphore, DISPATCH_TIME_NOW) == 0);
-		
+
+		#if !OS_OBJECT_USE_OBJC
 		dispatch_release(delGroup);
 		dispatch_release(semaphore);
-		
+		#endif
+
 		NSLog(@"%@ (Any YES -> YES, otherwise NO) = %@", NSStringFromSelector(selector), (result ? @"YES" : @"NO"));
 	}
 }


### PR DESCRIPTION
All uses of dispatch_get_current_queue (deprecated since iOS 6.0) are removed,
and replaced by assigning a static queue tag, which is checked for its value.
Inside the queue, the specific will return itself, while outside the queue it
will return NULL, which will make the check fail.

Only two instances of dispatch_get_current_queue remain, both have been
surrounded by pragmas to disable the warning by the Clang compiler.
- DDLog.m: obtaining the current queue label.
- DelegateTesters.m: obtaining the current queue label for NSLog.
