### PR TITLE
Fix node creation when using options dictionary

### DIFF
--- a/Extensions/XEP-0060/XMPPPubSub.m
+++ b/Extensions/XEP-0060/XMPPPubSub.m
@@ -305,6 +305,7 @@
 	NSXMLElement *ps = [NSXMLElement elementWithName:@"pubsub" xmlns:NS_PUBSUB];
 	NSXMLElement *create = [NSXMLElement elementWithName:@"create"];
 	[create addAttributeWithName:@"node" stringValue:node];
+    [ps addChild:create];
 
 	if (options != nil && [options count] > 0)
 	{
@@ -327,9 +328,9 @@
 		{
 			f = [NSXMLElement elementWithName:@"field"];
 			[f addAttributeWithName:@"var"
-			            stringValue:[NSString stringWithFormat:@"pubsub#%@", [options valueForKey:item]]];
+			            stringValue:[NSString stringWithFormat:@"pubsub#%@", item]];
 			v = [NSXMLElement elementWithName:@"value"];
-			[v setStringValue:item];
+			[v setStringValue:[options valueForKey:item]];
 			[f addChild:v];
 			[x addChild:f];
 		}
@@ -339,7 +340,6 @@
 
 	}
 
-	[ps addChild:create];
 	[iq addChild:ps];
 
 	[xmppStream sendElement:iq];


### PR DESCRIPTION
1. Create node should precede configure node instead of following it
2. The values in the options dictionary should be the option values, and the keys the field names, instead of reversed

The current version of -createNode:WithOptions: works correctly only when there are no options, since the `<configure>` node is then omitted entirely.

I tested this on two servers (ejabberd and jabberd2) and had the same problem: both return a 501 feature-not-implemented when the `<configure>` element appears before the `<create>` element.

I tested the fix with ejabberd.
