### PR TITLE
Fix array-bounds crash in XMPPPubSub when parsing ping-response IQs

### DIFF
--- a/Extensions/XEP-0060/XMPPPubSub.m
+++ b/Extensions/XEP-0060/XMPPPubSub.m
@@ -107,7 +107,7 @@
             NSString *elementID = [iq attributeStringValueForName:@"id"];
             if (elementID) {
                 NSArray * elementIDComp = [elementID componentsSeparatedByString:@":"];
-                if (elementIDComp > 0) {
+                if ([elementIDComp count] > 0) {
                     NSString * opType = [elementIDComp objectAtIndex:1];
                     
                     if ([opType isEqualToString:@"publish_node"]) {


### PR DESCRIPTION
Existing code raises an exception on e.g.:
<iq xmlns="jabber:client" id="3FA360E2-EB57-4F71-A645-183C53555773" type="result"></iq>
