### PR TITLE
Add room JID as parameter to XMPPMUC delegate methods

### DIFF
--- a/Extensions/XEP-0045/XMPPMUC.h
+++ b/Extensions/XEP-0045/XMPPMUC.h
@@ -56,7 +56,7 @@
 @protocol XMPPMUCDelegate
 @optional
 
-- (void)xmppMUC:(XMPPMUC *)sender didReceiveRoomInvitation:(XMPPMessage *)message;
-- (void)xmppMUC:(XMPPMUC *)sender didReceiveRoomInvitationDecline:(XMPPMessage *)message;
+- (void)xmppMUC:(XMPPMUC *)sender roomJID:(XMPPJID *) roomJID didReceiveInvitation:(XMPPMessage *)message;
+- (void)xmppMUC:(XMPPMUC *)sender roomJID:(XMPPJID *) roomJID didReceiveInvitationDecline:(XMPPMessage *)message;
 
 @end

--- a/Extensions/XEP-0045/XMPPMUC.m
+++ b/Extensions/XEP-0045/XMPPMUC.m
@@ -169,14 +169,16 @@
 	NSXMLElement * decline = [x elementForName:@"decline"];
 	
 	NSXMLElement * directInvite = [message elementForName:@"x" xmlns:@"jabber:x:conference"];
+    
+    XMPPJID * roomJID = [message from];
 	
 	if (invite || directInvite)
 	{
-		[multicastDelegate xmppMUC:self didReceiveRoomInvitation:message];
+		[multicastDelegate xmppMUC:self roomJID:roomJID didReceiveInvitation:message];
 	}
 	else if (decline)
 	{
-		[multicastDelegate xmppMUC:self didReceiveRoomInvitationDecline:message];
+		[multicastDelegate xmppMUC:self roomJID:roomJID didReceiveInvitationDecline:message];
 	}
 }
 


### PR DESCRIPTION
Passing this always-needed parameter here clarifies the semantics of this delegate callback. Even the simplest delegate implementation will need the room JID to handle the invitation request (e.g. to pass to XMPPRoom). It takes some digging into the MUC protocol to realize that the room JID is the from address.
