### PR TITLE
Fixed TLS support on XMPPStream

### DIFF
--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -105,6 +105,14 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
 **/
 @property (readwrite, assign) UInt16 hostPort;
 
+
+/**
+ * When this property is set to YES, if the server supports TLS authentication, TLS will be used to authenticate.
+**/
+
+@property (nonatomic) BOOL useTLSIfSupported;
+
+
 /**
  * The JID of the user.
  * 

--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -3107,7 +3107,7 @@ enum XMPPStreamConfig
 	
 	if (f_starttls)
 	{
-		if ([f_starttls elementForName:@"required"])
+		if ([f_starttls elementForName:@"required"] || self.useTLSIfSupported )
 		{
 			// TLS is required for this connection
 			


### PR DESCRIPTION
Added a property to make TLS the default auth mechanism if the server supports it
