### PR TITLE
Update NSXMLElement+XEP_0203.m

### DIFF
--- a/Extensions/XEP-0203/NSXMLElement+XEP_0203.m
+++ b/Extensions/XEP-0203/NSXMLElement+XEP_0203.m
@@ -60,7 +60,7 @@
 	//     from='capulet.com'
 	//    stamp='20020910T23:08:25'>
 	
-	delay = [self elementForName:@"delay" xmlns:@"jabber:x:delay"];
+	delay = [self elementForName:@"x" xmlns:@"jabber:x:delay"];
 	if (delay)
 	{
 		NSDate *stamp;


### PR DESCRIPTION
Fix Typo in XEP_0203

When working with XEP-0091 (Legacy Delayed Delivery) the elementName should be x and not delay
