### PR TITLE
Use bundleForClass instead of mainBundle.

### DIFF
--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
@@ -464,11 +464,11 @@ static NSMutableSet *databaseFileNames;
 		
 		XMPPLogVerbose(@"%@: Creating managedObjectModel (%@)", [self class], momName);
 		
-		NSString *momPath = [[NSBundle mainBundle] pathForResource:momName ofType:@"mom"];
+		NSString *momPath = [[NSBundle bundleForClass:self.class] pathForResource:momName ofType:@"mom"];
 		if (momPath == nil)
 		{
 			// The model may be versioned or created with Xcode 4, try momd as an extension.
-			momPath = [[NSBundle mainBundle] pathForResource:momName ofType:@"momd"];
+			momPath = [[NSBundle bundleForClass:self.class] pathForResource:momName ofType:@"momd"];
 		}
     
 		if (momPath)


### PR DESCRIPTION
If you've copied and pasted the whole XMPPFramework into your current project, it will act just the same, but if you're using a separate framework for it, it will correctly find your .mom and .momd files.

Just a fix that my app uses, that I thought would be helpful.
