### PR TITLE
Add "id" attribute into the bind resource iq

### DIFF
--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -3387,6 +3387,7 @@ enum XMPPStreamConfig
 			
 			NSXMLElement *iq = [NSXMLElement elementWithName:@"iq"];
 			[iq addAttributeWithName:@"type" stringValue:@"set"];
+            [iq addAttributeWithName:@"id" stringValue:[self generateUUID]];
 			[iq addChild:session];
 			
 			NSString *outgoingStr = [iq compactXMLString];


### PR DESCRIPTION
Apache Vysper fail to authenticate if there is no "id" attribute in iq
