### PR TITLE
Rename LibIDN to XMPPStringPrep

### DIFF
--- a/Core/XMPPJID.m
+++ b/Core/XMPPJID.m
@@ -1,5 +1,5 @@
 #import "XMPPJID.h"
-#import "LibIDN.h"
+#import "XMPPStringPrep.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
@@ -92,9 +92,9 @@
 		}
 	}
 	
-	NSString *prepUser = [LibIDN prepNode:rawUser];
-	NSString *prepDomain = [LibIDN prepDomain:rawDomain];
-	NSString *prepResource = [LibIDN prepResource:rawResource];
+	NSString *prepUser = [XMPPStringPrep prepNode:rawUser];
+	NSString *prepDomain = [XMPPStringPrep prepDomain:rawDomain];
+	NSString *prepResource = [XMPPStringPrep prepResource:rawResource];
 	
 	if ([XMPPJID validateUser:prepUser domain:prepDomain resource:prepResource])
 	{
@@ -129,7 +129,7 @@
 
 + (XMPPJID *)jidWithString:(NSString *)jidStr resource:(NSString *)resource
 {
-	NSString *prepResource = [LibIDN prepResource:resource];
+	NSString *prepResource = [XMPPStringPrep prepResource:resource];
 	if (![self validateResource:prepResource]) return nil;
 	
 	NSString *user;
@@ -150,9 +150,9 @@
 
 + (XMPPJID *)jidWithUser:(NSString *)user domain:(NSString *)domain resource:(NSString *)resource
 {
-	NSString *prepUser = [LibIDN prepNode:user];
-	NSString *prepDomain = [LibIDN prepDomain:domain];
-	NSString *prepResource = [LibIDN prepResource:resource];
+	NSString *prepUser = [XMPPStringPrep prepNode:user];
+	NSString *prepDomain = [XMPPStringPrep prepDomain:domain];
+	NSString *prepResource = [XMPPStringPrep prepResource:resource];
 	
 	if ([XMPPJID validateUser:prepUser domain:prepDomain resource:prepResource])
 	{
@@ -183,7 +183,7 @@
                   prevalidatedDomain:(NSString *)domain
                             resource:(NSString *)resource
 {
-	NSString *prepResource = [LibIDN prepResource:resource];
+	NSString *prepResource = [XMPPStringPrep prepResource:resource];
 	if (![self validateResource:prepResource]) return nil;
 	
 	XMPPJID *jid = [[XMPPJID alloc] init];

--- a/Utilities/XMPPStringPrep.h
+++ b/Utilities/XMPPStringPrep.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 
 
-@interface LibIDN : NSObject
+@interface XMPPStringPrep : NSObject
 
 /**
  * Preps a node identifier for use in a JID.

--- a/Utilities/XMPPStringPrep.m
+++ b/Utilities/XMPPStringPrep.m
@@ -1,8 +1,8 @@
-#import "LibIDN.h"
+#import "XMPPStringPrep.h"
 #import "stringprep.h"
 
 
-@implementation LibIDN
+@implementation XMPPStringPrep
 
 + (NSString *)prepNode:(NSString *)node
 {

--- a/Xcode/DesktopXMPP/XMPPStream.xcodeproj/project.pbxproj
+++ b/Xcode/DesktopXMPP/XMPPStream.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		DC7302D312F3D26700549AC7 /* XMPPCapsCoreDataStorageObject.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7302CE12F3D26700549AC7 /* XMPPCapsCoreDataStorageObject.m */; };
 		DC7302D412F3D26700549AC7 /* XMPPCapsResourceCoreDataStorageObject.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7302D012F3D26700549AC7 /* XMPPCapsResourceCoreDataStorageObject.m */; };
 		DC73031312F532BF00549AC7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC73031212F532BF00549AC7 /* Security.framework */; };
-		DC84BAE4124407B60055A459 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BAE1124407B60055A459 /* LibIDN.m */; };
+		DC84BAE4124407B60055A459 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BAE1124407B60055A459 /* XMPPStringPrep.m */; };
 		DC84BAE5124407B60055A459 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BAE3124407B60055A459 /* GCDMulticastDelegate.m */; };
 		DC84BB03124407F50055A459 /* XMPPElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BAF2124407F50055A459 /* XMPPElement.m */; };
 		DC84BB04124407F50055A459 /* XMPPIQ.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BAF4124407F50055A459 /* XMPPIQ.m */; };
@@ -248,8 +248,8 @@
 		DC73031212F532BF00549AC7 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		DC84BAD6124407510055A459 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "idn-int.h"; path = "../../Vendor/libidn/idn-int.h"; sourceTree = SOURCE_ROOT; };
 		DC84BAD7124407510055A459 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stringprep.h; path = ../../Vendor/libidn/stringprep.h; sourceTree = SOURCE_ROOT; };
-		DC84BAE0124407B60055A459 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../Utilities/LibIDN.h; sourceTree = SOURCE_ROOT; };
-		DC84BAE1124407B60055A459 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../Utilities/LibIDN.m; sourceTree = SOURCE_ROOT; };
+		DC84BAE0124407B60055A459 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../Utilities/XMPPStringPrep.h; sourceTree = SOURCE_ROOT; };
+		DC84BAE1124407B60055A459 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../Utilities/XMPPStringPrep.m; sourceTree = SOURCE_ROOT; };
 		DC84BAE2124407B60055A459 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GCDMulticastDelegate.h; path = ../../Utilities/GCDMulticastDelegate.h; sourceTree = SOURCE_ROOT; };
 		DC84BAE3124407B60055A459 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GCDMulticastDelegate.m; path = ../../Utilities/GCDMulticastDelegate.m; sourceTree = SOURCE_ROOT; };
 		DC84BAF0124407F50055A459 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPP.h; path = ../../Core/XMPP.h; sourceTree = SOURCE_ROOT; };
@@ -930,8 +930,8 @@
 				DC73028212F37F8A00549AC7 /* DDList.m */,
 				DC84BAE2124407B60055A459 /* GCDMulticastDelegate.h */,
 				DC84BAE3124407B60055A459 /* GCDMulticastDelegate.m */,
-				DC84BAE0124407B60055A459 /* LibIDN.h */,
-				DC84BAE1124407B60055A459 /* LibIDN.m */,
+				DC84BAE0124407B60055A459 /* XMPPStringPrep.h */,
+				DC84BAE1124407B60055A459 /* XMPPStringPrep.m */,
 				07AF18A7134BC3C30084D82A /* XMPPSRVResolver.h */,
 				07AF18A8134BC3C30084D82A /* XMPPSRVResolver.m */,
 			);
@@ -1154,7 +1154,7 @@
 				DCF825F50D749A5100BFABDE /* ChatController.m in Sources */,
 				DCF8260F0D74A5A000BFABDE /* WindowManager.m in Sources */,
 				DC6E98ED1098A4C700070ADE /* AppDelegate.m in Sources */,
-				DC84BAE4124407B60055A459 /* LibIDN.m in Sources */,
+				DC84BAE4124407B60055A459 /* XMPPStringPrep.m in Sources */,
 				DC84BAE5124407B60055A459 /* GCDMulticastDelegate.m in Sources */,
 				DC84BB03124407F50055A459 /* XMPPElement.m in Sources */,
 				DC84BB04124407F50055A459 /* XMPPIQ.m in Sources */,

--- a/Xcode/ServerlessDemo/ServerlessDemo.xcodeproj/project.pbxproj
+++ b/Xcode/ServerlessDemo/ServerlessDemo.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		DC84BC7C12440D6B0055A459 /* DDXMLDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC7412440D6B0055A459 /* DDXMLDocument.m */; };
 		DC84BC7D12440D6B0055A459 /* DDXMLElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC7612440D6B0055A459 /* DDXMLElement.m */; };
 		DC84BC7E12440D6B0055A459 /* DDXMLNode.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC7812440D6B0055A459 /* DDXMLNode.m */; };
-		DC84BC9312440DBE0055A459 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC8E12440DBE0055A459 /* LibIDN.m */; };
+		DC84BC9312440DBE0055A459 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC8E12440DBE0055A459 /* XMPPStringPrep.m */; };
 		DC84BCA912440DD80055A459 /* XMPPElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC9812440DD80055A459 /* XMPPElement.m */; };
 		DC84BCAA12440DD80055A459 /* XMPPIQ.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC9A12440DD80055A459 /* XMPPIQ.m */; };
 		DC84BCAB12440DD80055A459 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BC9C12440DD80055A459 /* XMPPJID.m */; };
@@ -113,8 +113,8 @@
 		DC84BC7612440D6B0055A459 /* DDXMLElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DDXMLElement.m; path = ../../Vendor/KissXML/DDXMLElement.m; sourceTree = SOURCE_ROOT; };
 		DC84BC7712440D6B0055A459 /* DDXMLNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DDXMLNode.h; path = ../../Vendor/KissXML/DDXMLNode.h; sourceTree = SOURCE_ROOT; };
 		DC84BC7812440D6B0055A459 /* DDXMLNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DDXMLNode.m; path = ../../Vendor/KissXML/DDXMLNode.m; sourceTree = SOURCE_ROOT; };
-		DC84BC8D12440DBE0055A459 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../Utilities/LibIDN.h; sourceTree = SOURCE_ROOT; };
-		DC84BC8E12440DBE0055A459 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../Utilities/LibIDN.m; sourceTree = SOURCE_ROOT; };
+		DC84BC8D12440DBE0055A459 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../Utilities/XMPPStringPrep.h; sourceTree = SOURCE_ROOT; };
+		DC84BC8E12440DBE0055A459 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../Utilities/XMPPStringPrep.m; sourceTree = SOURCE_ROOT; };
 		DC84BC9612440DD80055A459 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPP.h; path = ../../Core/XMPP.h; sourceTree = SOURCE_ROOT; };
 		DC84BC9712440DD80055A459 /* XMPPElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPElement.h; path = ../../Core/XMPPElement.h; sourceTree = SOURCE_ROOT; };
 		DC84BC9812440DD80055A459 /* XMPPElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPElement.m; path = ../../Core/XMPPElement.m; sourceTree = SOURCE_ROOT; };
@@ -512,8 +512,8 @@
 			children = (
 				07AF18BB134BC4960084D82A /* XMPPSRVResolver.h */,
 				07AF18BC134BC4960084D82A /* XMPPSRVResolver.m */,
-				DC84BC8D12440DBE0055A459 /* LibIDN.h */,
-				DC84BC8E12440DBE0055A459 /* LibIDN.m */,
+				DC84BC8D12440DBE0055A459 /* XMPPStringPrep.h */,
+				DC84BC8E12440DBE0055A459 /* XMPPStringPrep.m */,
 				DCB81EB6130AC9C3002ACF2E /* GCDMulticastDelegate.h */,
 				DCB81EB7130AC9C3002ACF2E /* GCDMulticastDelegate.m */,
 				DCB81EB4130AC9C3002ACF2E /* DDList.h */,
@@ -605,7 +605,7 @@
 				DC84BC7C12440D6B0055A459 /* DDXMLDocument.m in Sources */,
 				DC84BC7D12440D6B0055A459 /* DDXMLElement.m in Sources */,
 				DC84BC7E12440D6B0055A459 /* DDXMLNode.m in Sources */,
-				DC84BC9312440DBE0055A459 /* LibIDN.m in Sources */,
+				DC84BC9312440DBE0055A459 /* XMPPStringPrep.m in Sources */,
 				DC84BCA912440DD80055A459 /* XMPPElement.m in Sources */,
 				DC84BCAA12440DD80055A459 /* XMPPIQ.m in Sources */,
 				DC84BCAB12440DD80055A459 /* XMPPJID.m in Sources */,

--- a/Xcode/Testing/AutoPingTest/Desktop/AutoPingTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoPingTest/Desktop/AutoPingTest.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		DC597F9014101FBF0050774C /* XMPPPing.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F2314101FBF0050774C /* XMPPPing.m */; };
 		DC597F9414101FBF0050774C /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F2E14101FBF0050774C /* DDList.m */; };
 		DC597F9514101FBF0050774C /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F3014101FBF0050774C /* GCDMulticastDelegate.m */; };
-		DC597F9614101FBF0050774C /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F3214101FBF0050774C /* LibIDN.m */; };
+		DC597F9614101FBF0050774C /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F3214101FBF0050774C /* XMPPStringPrep.m */; };
 		DC597F9714101FBF0050774C /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F3414101FBF0050774C /* RFImageToDataTransformer.m */; };
 		DC597F9814101FBF0050774C /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F3614101FBF0050774C /* XMPPIDTracker.m */; };
 		DC597F9914101FBF0050774C /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = DC597F3814101FBF0050774C /* XMPPSRVResolver.m */; };
@@ -128,8 +128,8 @@
 		DC597F2E14101FBF0050774C /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DC597F2F14101FBF0050774C /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DC597F3014101FBF0050774C /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DC597F3114101FBF0050774C /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DC597F3214101FBF0050774C /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DC597F3114101FBF0050774C /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DC597F3214101FBF0050774C /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DC597F3314101FBF0050774C /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
 		DC597F3414101FBF0050774C /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
 		DC597F3514101FBF0050774C /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
@@ -409,8 +409,8 @@
 				DC597F2E14101FBF0050774C /* DDList.m */,
 				DC597F2F14101FBF0050774C /* GCDMulticastDelegate.h */,
 				DC597F3014101FBF0050774C /* GCDMulticastDelegate.m */,
-				DC597F3114101FBF0050774C /* LibIDN.h */,
-				DC597F3214101FBF0050774C /* LibIDN.m */,
+				DC597F3114101FBF0050774C /* XMPPStringPrep.h */,
+				DC597F3214101FBF0050774C /* XMPPStringPrep.m */,
 				DC597F3314101FBF0050774C /* RFImageToDataTransformer.h */,
 				DC597F3414101FBF0050774C /* RFImageToDataTransformer.m */,
 				DC597F3514101FBF0050774C /* XMPPIDTracker.h */,
@@ -551,7 +551,7 @@
 				DC597F9014101FBF0050774C /* XMPPPing.m in Sources */,
 				DC597F9414101FBF0050774C /* DDList.m in Sources */,
 				DC597F9514101FBF0050774C /* GCDMulticastDelegate.m in Sources */,
-				DC597F9614101FBF0050774C /* LibIDN.m in Sources */,
+				DC597F9614101FBF0050774C /* XMPPStringPrep.m in Sources */,
 				DC597F9714101FBF0050774C /* RFImageToDataTransformer.m in Sources */,
 				DC597F9814101FBF0050774C /* XMPPIDTracker.m in Sources */,
 				DC597F9914101FBF0050774C /* XMPPSRVResolver.m in Sources */,

--- a/Xcode/Testing/AutoPingTest/Mobile/AutoPingTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoPingTest/Mobile/AutoPingTest.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		DC5981F2141033210050774C /* XMPPPing.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598185141033210050774C /* XMPPPing.m */; };
 		DC5981F6141033210050774C /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598190141033210050774C /* DDList.m */; };
 		DC5981F7141033210050774C /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598192141033210050774C /* GCDMulticastDelegate.m */; };
-		DC5981F8141033210050774C /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598194141033210050774C /* LibIDN.m */; };
+		DC5981F8141033210050774C /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598194141033210050774C /* XMPPStringPrep.m */; };
 		DC5981F9141033210050774C /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598196141033210050774C /* RFImageToDataTransformer.m */; };
 		DC5981FA141033210050774C /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = DC598198141033210050774C /* XMPPIDTracker.m */; };
 		DC5981FB141033210050774C /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = DC59819A141033210050774C /* XMPPSRVResolver.m */; };
@@ -129,8 +129,8 @@
 		DC598190141033210050774C /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DC598191141033210050774C /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DC598192141033210050774C /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DC598193141033210050774C /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DC598194141033210050774C /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DC598193141033210050774C /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DC598194141033210050774C /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DC598195141033210050774C /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
 		DC598196141033210050774C /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
 		DC598197141033210050774C /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
@@ -404,8 +404,8 @@
 				DC598190141033210050774C /* DDList.m */,
 				DC598191141033210050774C /* GCDMulticastDelegate.h */,
 				DC598192141033210050774C /* GCDMulticastDelegate.m */,
-				DC598193141033210050774C /* LibIDN.h */,
-				DC598194141033210050774C /* LibIDN.m */,
+				DC598193141033210050774C /* XMPPStringPrep.h */,
+				DC598194141033210050774C /* XMPPStringPrep.m */,
 				DC598195141033210050774C /* RFImageToDataTransformer.h */,
 				DC598196141033210050774C /* RFImageToDataTransformer.m */,
 				DC598197141033210050774C /* XMPPIDTracker.h */,
@@ -581,7 +581,7 @@
 				DC5981F2141033210050774C /* XMPPPing.m in Sources */,
 				DC5981F6141033210050774C /* DDList.m in Sources */,
 				DC5981F7141033210050774C /* GCDMulticastDelegate.m in Sources */,
-				DC5981F8141033210050774C /* LibIDN.m in Sources */,
+				DC5981F8141033210050774C /* XMPPStringPrep.m in Sources */,
 				DC5981F9141033210050774C /* RFImageToDataTransformer.m in Sources */,
 				DC5981FA141033210050774C /* XMPPIDTracker.m in Sources */,
 				DC5981FB141033210050774C /* XMPPSRVResolver.m in Sources */,

--- a/Xcode/Testing/AutoTimeTest/Desktop/AutoTimeTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoTimeTest/Desktop/AutoTimeTest.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		DC30E51D153DFFAD001B9E6D /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E47D153DFFAD001B9E6D /* XMPPStream.m */; };
 		DC30E51E153DFFAD001B9E6D /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E480153DFFAD001B9E6D /* DDList.m */; };
 		DC30E51F153DFFAD001B9E6D /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E482153DFFAD001B9E6D /* GCDMulticastDelegate.m */; };
-		DC30E520153DFFAD001B9E6D /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E484153DFFAD001B9E6D /* LibIDN.m */; };
+		DC30E520153DFFAD001B9E6D /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E484153DFFAD001B9E6D /* XMPPStringPrep.m */; };
 		DC30E521153DFFAD001B9E6D /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E486153DFFAD001B9E6D /* RFImageToDataTransformer.m */; };
 		DC30E523153DFFAD001B9E6D /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E48A153DFFAD001B9E6D /* XMPPIDTracker.m */; };
 		DC30E524153DFFAD001B9E6D /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E48D153DFFAD001B9E6D /* XMPPSRVResolver.m */; };
@@ -90,8 +90,8 @@
 		DC30E480153DFFAD001B9E6D /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DC30E481153DFFAD001B9E6D /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DC30E482153DFFAD001B9E6D /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DC30E483153DFFAD001B9E6D /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DC30E484153DFFAD001B9E6D /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DC30E483153DFFAD001B9E6D /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DC30E484153DFFAD001B9E6D /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DC30E485153DFFAD001B9E6D /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
 		DC30E486153DFFAD001B9E6D /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
 		DC30E489153DFFAD001B9E6D /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
@@ -246,8 +246,8 @@
 				DC30E480153DFFAD001B9E6D /* DDList.m */,
 				DC30E481153DFFAD001B9E6D /* GCDMulticastDelegate.h */,
 				DC30E482153DFFAD001B9E6D /* GCDMulticastDelegate.m */,
-				DC30E483153DFFAD001B9E6D /* LibIDN.h */,
-				DC30E484153DFFAD001B9E6D /* LibIDN.m */,
+				DC30E483153DFFAD001B9E6D /* XMPPStringPrep.h */,
+				DC30E484153DFFAD001B9E6D /* XMPPStringPrep.m */,
 				DC30E485153DFFAD001B9E6D /* RFImageToDataTransformer.h */,
 				DC30E486153DFFAD001B9E6D /* RFImageToDataTransformer.m */,
 				DC30E489153DFFAD001B9E6D /* XMPPIDTracker.h */,
@@ -563,7 +563,7 @@
 				DC30E51D153DFFAD001B9E6D /* XMPPStream.m in Sources */,
 				DC30E51E153DFFAD001B9E6D /* DDList.m in Sources */,
 				DC30E51F153DFFAD001B9E6D /* GCDMulticastDelegate.m in Sources */,
-				DC30E520153DFFAD001B9E6D /* LibIDN.m in Sources */,
+				DC30E520153DFFAD001B9E6D /* XMPPStringPrep.m in Sources */,
 				DC30E521153DFFAD001B9E6D /* RFImageToDataTransformer.m in Sources */,
 				DC30E523153DFFAD001B9E6D /* XMPPIDTracker.m in Sources */,
 				DC30E524153DFFAD001B9E6D /* XMPPSRVResolver.m in Sources */,

--- a/Xcode/Testing/AutoTimeTest/Mobile/AutoTimeTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoTimeTest/Mobile/AutoTimeTest.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		DC30E3FC153DFE52001B9E6D /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E35C153DFE52001B9E6D /* XMPPStream.m */; };
 		DC30E3FD153DFE52001B9E6D /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E35F153DFE52001B9E6D /* DDList.m */; };
 		DC30E3FE153DFE52001B9E6D /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E361153DFE52001B9E6D /* GCDMulticastDelegate.m */; };
-		DC30E3FF153DFE52001B9E6D /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E363153DFE52001B9E6D /* LibIDN.m */; };
+		DC30E3FF153DFE52001B9E6D /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E363153DFE52001B9E6D /* XMPPStringPrep.m */; };
 		DC30E400153DFE52001B9E6D /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E365153DFE52001B9E6D /* RFImageToDataTransformer.m */; };
 		DC30E402153DFE52001B9E6D /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E369153DFE52001B9E6D /* XMPPIDTracker.m */; };
 		DC30E403153DFE52001B9E6D /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E36C153DFE52001B9E6D /* XMPPSRVResolver.m */; };
@@ -104,8 +104,8 @@
 		DC30E35F153DFE52001B9E6D /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DC30E360153DFE52001B9E6D /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DC30E361153DFE52001B9E6D /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DC30E362153DFE52001B9E6D /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DC30E363153DFE52001B9E6D /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DC30E362153DFE52001B9E6D /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DC30E363153DFE52001B9E6D /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DC30E364153DFE52001B9E6D /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
 		DC30E365153DFE52001B9E6D /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
 		DC30E368153DFE52001B9E6D /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
@@ -253,8 +253,8 @@
 				DC30E35F153DFE52001B9E6D /* DDList.m */,
 				DC30E360153DFE52001B9E6D /* GCDMulticastDelegate.h */,
 				DC30E361153DFE52001B9E6D /* GCDMulticastDelegate.m */,
-				DC30E362153DFE52001B9E6D /* LibIDN.h */,
-				DC30E363153DFE52001B9E6D /* LibIDN.m */,
+				DC30E362153DFE52001B9E6D /* XMPPStringPrep.h */,
+				DC30E363153DFE52001B9E6D /* XMPPStringPrep.m */,
 				DC30E364153DFE52001B9E6D /* RFImageToDataTransformer.h */,
 				DC30E365153DFE52001B9E6D /* RFImageToDataTransformer.m */,
 				DC30E368153DFE52001B9E6D /* XMPPIDTracker.h */,
@@ -602,7 +602,7 @@
 				DC30E3FC153DFE52001B9E6D /* XMPPStream.m in Sources */,
 				DC30E3FD153DFE52001B9E6D /* DDList.m in Sources */,
 				DC30E3FE153DFE52001B9E6D /* GCDMulticastDelegate.m in Sources */,
-				DC30E3FF153DFE52001B9E6D /* LibIDN.m in Sources */,
+				DC30E3FF153DFE52001B9E6D /* XMPPStringPrep.m in Sources */,
 				DC30E400153DFE52001B9E6D /* RFImageToDataTransformer.m in Sources */,
 				DC30E402153DFE52001B9E6D /* XMPPIDTracker.m in Sources */,
 				DC30E403153DFE52001B9E6D /* XMPPSRVResolver.m in Sources */,

--- a/Xcode/Testing/EncodeDecodeTest/Desktop/EncodeDecodeTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/EncodeDecodeTest/Desktop/EncodeDecodeTest.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		DC34A2DB1488A0F9004F0A03 /* NSXMLElement+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A2DA1488A0F9004F0A03 /* NSXMLElement+XMPP.m */; };
 		DC34A2DE1488A10F004F0A03 /* NSNumber+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A2DD1488A10F004F0A03 /* NSNumber+XMPP.m */; };
 		DC34A2E11488A134004F0A03 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A2E01488A134004F0A03 /* XMPPJID.m */; };
-		DC34A2E51488A14A004F0A03 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A2E41488A14A004F0A03 /* LibIDN.m */; };
+		DC34A2E51488A14A004F0A03 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A2E41488A14A004F0A03 /* XMPPStringPrep.m */; };
 		DC34A2ED1488A16B004F0A03 /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC34A2EA1488A16B004F0A03 /* libidn.a */; };
 /* End PBXBuildFile section */
 
@@ -52,8 +52,8 @@
 		DC34A2DD1488A10F004F0A03 /* NSNumber+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSNumber+XMPP.m"; path = "../../../../Categories/NSNumber+XMPP.m"; sourceTree = "<group>"; };
 		DC34A2DF1488A134004F0A03 /* XMPPJID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPJID.h; path = ../../../../Core/XMPPJID.h; sourceTree = "<group>"; };
 		DC34A2E01488A134004F0A03 /* XMPPJID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPJID.m; path = ../../../../Core/XMPPJID.m; sourceTree = "<group>"; };
-		DC34A2E31488A14A004F0A03 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../../../Utilities/LibIDN.h; sourceTree = "<group>"; };
-		DC34A2E41488A14A004F0A03 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../../../Utilities/LibIDN.m; sourceTree = "<group>"; };
+		DC34A2E31488A14A004F0A03 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../../../Utilities/XMPPStringPrep.h; sourceTree = "<group>"; };
+		DC34A2E41488A14A004F0A03 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../../../Utilities/XMPPStringPrep.m; sourceTree = "<group>"; };
 		DC34A2E81488A16B004F0A03 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "idn-int.h"; sourceTree = "<group>"; };
 		DC34A2EA1488A16B004F0A03 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libidn.a; sourceTree = "<group>"; };
 		DC34A2EB1488A16B004F0A03 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stringprep.h; sourceTree = "<group>"; };
@@ -174,8 +174,8 @@
 		DC34A2E21488A13E004F0A03 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DC34A2E31488A14A004F0A03 /* LibIDN.h */,
-				DC34A2E41488A14A004F0A03 /* LibIDN.m */,
+				DC34A2E31488A14A004F0A03 /* XMPPStringPrep.h */,
+				DC34A2E41488A14A004F0A03 /* XMPPStringPrep.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -271,7 +271,7 @@
 				DC34A2DB1488A0F9004F0A03 /* NSXMLElement+XMPP.m in Sources */,
 				DC34A2DE1488A10F004F0A03 /* NSNumber+XMPP.m in Sources */,
 				DC34A2E11488A134004F0A03 /* XMPPJID.m in Sources */,
-				DC34A2E51488A14A004F0A03 /* LibIDN.m in Sources */,
+				DC34A2E51488A14A004F0A03 /* XMPPStringPrep.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xcode/Testing/EncodeDecodeTest/Mobile/EncodeDecodeTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/EncodeDecodeTest/Mobile/EncodeDecodeTest.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		DC34A34E1488AC34004F0A03 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A3471488AC34004F0A03 /* XMPPJID.m */; };
 		DC34A34F1488AC34004F0A03 /* XMPPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A3491488AC34004F0A03 /* XMPPMessage.m */; };
 		DC34A3501488AC34004F0A03 /* XMPPPresence.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A34B1488AC34004F0A03 /* XMPPPresence.m */; };
-		DC34A3531488AC44004F0A03 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A3521488AC44004F0A03 /* LibIDN.m */; };
+		DC34A3531488AC44004F0A03 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC34A3521488AC44004F0A03 /* XMPPStringPrep.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -71,8 +71,8 @@
 		DC34A3491488AC34004F0A03 /* XMPPMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPMessage.m; path = ../../../../Core/XMPPMessage.m; sourceTree = "<group>"; };
 		DC34A34A1488AC34004F0A03 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPPresence.h; path = ../../../../Core/XMPPPresence.h; sourceTree = "<group>"; };
 		DC34A34B1488AC34004F0A03 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPresence.m; path = ../../../../Core/XMPPPresence.m; sourceTree = "<group>"; };
-		DC34A3511488AC44004F0A03 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../../../Utilities/LibIDN.h; sourceTree = "<group>"; };
-		DC34A3521488AC44004F0A03 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../../../Utilities/LibIDN.m; sourceTree = "<group>"; };
+		DC34A3511488AC44004F0A03 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../../../Utilities/XMPPStringPrep.h; sourceTree = "<group>"; };
+		DC34A3521488AC44004F0A03 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../../../Utilities/XMPPStringPrep.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -238,8 +238,8 @@
 		DC34A33B1488AC0B004F0A03 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DC34A3511488AC44004F0A03 /* LibIDN.h */,
-				DC34A3521488AC44004F0A03 /* LibIDN.m */,
+				DC34A3511488AC44004F0A03 /* XMPPStringPrep.h */,
+				DC34A3521488AC44004F0A03 /* XMPPStringPrep.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -320,7 +320,7 @@
 				DC34A34E1488AC34004F0A03 /* XMPPJID.m in Sources */,
 				DC34A34F1488AC34004F0A03 /* XMPPMessage.m in Sources */,
 				DC34A3501488AC34004F0A03 /* XMPPPresence.m in Sources */,
-				DC34A3531488AC44004F0A03 /* LibIDN.m in Sources */,
+				DC34A3531488AC44004F0A03 /* XMPPStringPrep.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xcode/Testing/FacebookTest/FacebookTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/FacebookTest/FacebookTest.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		DCC494FB1333043200F3C8F6 /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494C91333043200F3C8F6 /* XMPPStream.m */; };
 		DCC494FC1333043200F3C8F6 /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494CC1333043200F3C8F6 /* DDList.m */; };
 		DCC494FD1333043200F3C8F6 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494CE1333043200F3C8F6 /* GCDMulticastDelegate.m */; };
-		DCC494FE1333043200F3C8F6 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494D01333043200F3C8F6 /* LibIDN.m */; };
+		DCC494FE1333043200F3C8F6 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494D01333043200F3C8F6 /* XMPPStringPrep.m */; };
 		DCC495001333043200F3C8F6 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494D61333043200F3C8F6 /* GCDAsyncSocket.m */; };
 		DCC495011333043200F3C8F6 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494D91333043200F3C8F6 /* DDASLLogger.m */; };
 		DCC495021333043200F3C8F6 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC494DB1333043200F3C8F6 /* DDFileLogger.m */; };
@@ -145,8 +145,8 @@
 		DCC494CC1333043200F3C8F6 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DCC494CD1333043200F3C8F6 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DCC494CE1333043200F3C8F6 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DCC494CF1333043200F3C8F6 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DCC494D01333043200F3C8F6 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DCC494CF1333043200F3C8F6 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DCC494D01333043200F3C8F6 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DCC494D51333043200F3C8F6 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncSocket.h; sourceTree = "<group>"; };
 		DCC494D61333043200F3C8F6 /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncSocket.m; sourceTree = "<group>"; };
 		DCC494D81333043200F3C8F6 /* DDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDASLLogger.h; sourceTree = "<group>"; };
@@ -386,8 +386,8 @@
 			children = (
 				DCC494CD1333043200F3C8F6 /* GCDMulticastDelegate.h */,
 				DCC494CE1333043200F3C8F6 /* GCDMulticastDelegate.m */,
-				DCC494CF1333043200F3C8F6 /* LibIDN.h */,
-				DCC494D01333043200F3C8F6 /* LibIDN.m */,
+				DCC494CF1333043200F3C8F6 /* XMPPStringPrep.h */,
+				DCC494D01333043200F3C8F6 /* XMPPStringPrep.m */,
 				DCF3C1371367276900111BA3 /* XMPPSRVResolver.h */,
 				DCF3C1381367276900111BA3 /* XMPPSRVResolver.m */,
 				DCC494CB1333043200F3C8F6 /* DDList.h */,
@@ -633,7 +633,7 @@
 				DCC494FB1333043200F3C8F6 /* XMPPStream.m in Sources */,
 				DCC494FC1333043200F3C8F6 /* DDList.m in Sources */,
 				DCC494FD1333043200F3C8F6 /* GCDMulticastDelegate.m in Sources */,
-				DCC494FE1333043200F3C8F6 /* LibIDN.m in Sources */,
+				DCC494FE1333043200F3C8F6 /* XMPPStringPrep.m in Sources */,
 				DCC495001333043200F3C8F6 /* GCDAsyncSocket.m in Sources */,
 				DCC495011333043200F3C8F6 /* DDASLLogger.m in Sources */,
 				DCC495021333043200F3C8F6 /* DDFileLogger.m in Sources */,

--- a/Xcode/Testing/MUCTesting/MUCTesting.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/MUCTesting/MUCTesting.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		DCC8902013EB5D0B00CDAB56 /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FE713EB5D0B00CDAB56 /* XMPPStream.m */; };
 		DCC8902113EB5D0B00CDAB56 /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FEA13EB5D0B00CDAB56 /* DDList.m */; };
 		DCC8902213EB5D0B00CDAB56 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FEC13EB5D0B00CDAB56 /* GCDMulticastDelegate.m */; };
-		DCC8902313EB5D0B00CDAB56 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FEE13EB5D0B00CDAB56 /* LibIDN.m */; };
+		DCC8902313EB5D0B00CDAB56 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FEE13EB5D0B00CDAB56 /* XMPPStringPrep.m */; };
 		DCC8902413EB5D0B00CDAB56 /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FF013EB5D0B00CDAB56 /* RFImageToDataTransformer.m */; };
 		DCC8902513EB5D0B00CDAB56 /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FF213EB5D0B00CDAB56 /* XMPPIDTracker.m */; };
 		DCC8902613EB5D0B00CDAB56 /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88FF413EB5D0B00CDAB56 /* XMPPSRVResolver.m */; };
@@ -123,8 +123,8 @@
 		DCC88FEA13EB5D0B00CDAB56 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DCC88FEB13EB5D0B00CDAB56 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DCC88FEC13EB5D0B00CDAB56 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DCC88FED13EB5D0B00CDAB56 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DCC88FEE13EB5D0B00CDAB56 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DCC88FED13EB5D0B00CDAB56 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DCC88FEE13EB5D0B00CDAB56 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DCC88FEF13EB5D0B00CDAB56 /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
 		DCC88FF013EB5D0B00CDAB56 /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
 		DCC88FF113EB5D0B00CDAB56 /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
@@ -385,8 +385,8 @@
 				DCC88FEA13EB5D0B00CDAB56 /* DDList.m */,
 				DCC88FEB13EB5D0B00CDAB56 /* GCDMulticastDelegate.h */,
 				DCC88FEC13EB5D0B00CDAB56 /* GCDMulticastDelegate.m */,
-				DCC88FED13EB5D0B00CDAB56 /* LibIDN.h */,
-				DCC88FEE13EB5D0B00CDAB56 /* LibIDN.m */,
+				DCC88FED13EB5D0B00CDAB56 /* XMPPStringPrep.h */,
+				DCC88FEE13EB5D0B00CDAB56 /* XMPPStringPrep.m */,
 				DCC88FEF13EB5D0B00CDAB56 /* RFImageToDataTransformer.h */,
 				DCC88FF013EB5D0B00CDAB56 /* RFImageToDataTransformer.m */,
 				DCC88FF113EB5D0B00CDAB56 /* XMPPIDTracker.h */,
@@ -659,7 +659,7 @@
 				DCC8902013EB5D0B00CDAB56 /* XMPPStream.m in Sources */,
 				DCC8902113EB5D0B00CDAB56 /* DDList.m in Sources */,
 				DCC8902213EB5D0B00CDAB56 /* GCDMulticastDelegate.m in Sources */,
-				DCC8902313EB5D0B00CDAB56 /* LibIDN.m in Sources */,
+				DCC8902313EB5D0B00CDAB56 /* XMPPStringPrep.m in Sources */,
 				DCC8902413EB5D0B00CDAB56 /* RFImageToDataTransformer.m in Sources */,
 				DCC8902513EB5D0B00CDAB56 /* XMPPIDTracker.m in Sources */,
 				DCC8902613EB5D0B00CDAB56 /* XMPPSRVResolver.m in Sources */,

--- a/Xcode/Testing/TestCapabilitiesHashing/Mac/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestCapabilitiesHashing/Mac/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		DCC0C23C130340D200EC45D2 /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C235130340D200EC45D2 /* XMPPStream.m */; };
 		DCC0C2531303412E00EC45D2 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C2521303412E00EC45D2 /* GCDAsyncSocket.m */; };
 		DCC0C2631303418B00EC45D2 /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C25E1303418B00EC45D2 /* DDList.m */; };
-		DCC0C2641303418B00EC45D2 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C2601303418B00EC45D2 /* LibIDN.m */; };
+		DCC0C2641303418B00EC45D2 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C2601303418B00EC45D2 /* XMPPStringPrep.m */; };
 		DCC0C270130341FE00EC45D2 /* libresolv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC0C26F130341FE00EC45D2 /* libresolv.dylib */; };
 		DCC0C2721303421500EC45D2 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC0C2711303421500EC45D2 /* libxml2.dylib */; };
 		DCC0C28A1303459A00EC45D2 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC0C2891303459A00EC45D2 /* Security.framework */; };
@@ -125,8 +125,8 @@
 		DCC0C2591303416E00EC45D2 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidn.a; path = "/Users/robbie/Programs/Google Code/XMPPFramework/Vendor/libidn/libidn.a"; sourceTree = "<absolute>"; };
 		DCC0C25D1303418B00EC45D2 /* DDList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DDList.h; path = ../../../../../Utilities/DDList.h; sourceTree = SOURCE_ROOT; };
 		DCC0C25E1303418B00EC45D2 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DDList.m; path = ../../../../../Utilities/DDList.m; sourceTree = SOURCE_ROOT; };
-		DCC0C25F1303418B00EC45D2 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../../../../Utilities/LibIDN.h; sourceTree = SOURCE_ROOT; };
-		DCC0C2601303418B00EC45D2 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../../../../Utilities/LibIDN.m; sourceTree = SOURCE_ROOT; };
+		DCC0C25F1303418B00EC45D2 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../../../../Utilities/XMPPStringPrep.h; sourceTree = SOURCE_ROOT; };
+		DCC0C2601303418B00EC45D2 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../../../../Utilities/XMPPStringPrep.m; sourceTree = SOURCE_ROOT; };
 		DCC0C268130341AD00EC45D2 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPP.h; path = ../../../../../Core/XMPP.h; sourceTree = SOURCE_ROOT; };
 		DCC0C26F130341FE00EC45D2 /* libresolv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libresolv.dylib; path = usr/lib/libresolv.dylib; sourceTree = SDKROOT; };
 		DCC0C2711303421500EC45D2 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
@@ -331,8 +331,8 @@
 				56F8384514C794BF00AF62B3 /* RFImageToDataTransformer.m */,
 				56F8384814C794BF00AF62B3 /* XMPPIDTracker.h */,
 				56F8384914C794BF00AF62B3 /* XMPPIDTracker.m */,
-				DCC0C25F1303418B00EC45D2 /* LibIDN.h */,
-				DCC0C2601303418B00EC45D2 /* LibIDN.m */,
+				DCC0C25F1303418B00EC45D2 /* XMPPStringPrep.h */,
+				DCC0C2601303418B00EC45D2 /* XMPPStringPrep.m */,
 				DCC0C2171303407000EC45D2 /* GCDMulticastDelegate.h */,
 				DCC0C2181303407000EC45D2 /* GCDMulticastDelegate.m */,
 				DCF3C18013672B0B00111BA3 /* XMPPSRVResolver.h */,
@@ -550,7 +550,7 @@
 				DCC0C23C130340D200EC45D2 /* XMPPStream.m in Sources */,
 				DCC0C2531303412E00EC45D2 /* GCDAsyncSocket.m in Sources */,
 				DCC0C2631303418B00EC45D2 /* DDList.m in Sources */,
-				DCC0C2641303418B00EC45D2 /* LibIDN.m in Sources */,
+				DCC0C2641303418B00EC45D2 /* XMPPStringPrep.m in Sources */,
 				DCC0C2E71303467700EC45D2 /* XMPPCapabilities.xcdatamodel in Sources */,
 				DCC0C2E81303467700EC45D2 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
 				DCC0C2E91303467700EC45D2 /* XMPPCapsCoreDataStorageObject.m in Sources */,

--- a/Xcode/Testing/TestCapabilitiesHashing/iPhone/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestCapabilitiesHashing/iPhone/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		DCC0C33B1303496E00EC45D2 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C33A1303496E00EC45D2 /* GCDAsyncSocket.m */; };
 		DCC0C348130349A600EC45D2 /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C341130349A600EC45D2 /* DDList.m */; };
 		DCC0C349130349A600EC45D2 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C343130349A600EC45D2 /* GCDMulticastDelegate.m */; };
-		DCC0C34A130349A600EC45D2 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C345130349A600EC45D2 /* LibIDN.m */; };
+		DCC0C34A130349A600EC45D2 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C345130349A600EC45D2 /* XMPPStringPrep.m */; };
 		DCC0C361130349C300EC45D2 /* XMPPElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C34F130349C300EC45D2 /* XMPPElement.m */; };
 		DCC0C362130349C300EC45D2 /* XMPPIQ.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C351130349C300EC45D2 /* XMPPIQ.m */; };
 		DCC0C363130349C300EC45D2 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC0C353130349C300EC45D2 /* XMPPJID.m */; };
@@ -124,8 +124,8 @@
 		DCC0C341130349A600EC45D2 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DDList.m; path = ../../../../../Utilities/DDList.m; sourceTree = SOURCE_ROOT; };
 		DCC0C342130349A600EC45D2 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GCDMulticastDelegate.h; path = ../../../../../Utilities/GCDMulticastDelegate.h; sourceTree = SOURCE_ROOT; };
 		DCC0C343130349A600EC45D2 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GCDMulticastDelegate.m; path = ../../../../../Utilities/GCDMulticastDelegate.m; sourceTree = SOURCE_ROOT; };
-		DCC0C344130349A600EC45D2 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../../../../Utilities/LibIDN.h; sourceTree = SOURCE_ROOT; };
-		DCC0C345130349A600EC45D2 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../../../../Utilities/LibIDN.m; sourceTree = SOURCE_ROOT; };
+		DCC0C344130349A600EC45D2 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../../../../Utilities/XMPPStringPrep.h; sourceTree = SOURCE_ROOT; };
+		DCC0C345130349A600EC45D2 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../../../../Utilities/XMPPStringPrep.m; sourceTree = SOURCE_ROOT; };
 		DCC0C34D130349C300EC45D2 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPP.h; path = ../../../../../Core/XMPP.h; sourceTree = SOURCE_ROOT; };
 		DCC0C34E130349C300EC45D2 /* XMPPElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPElement.h; path = ../../../../../Core/XMPPElement.h; sourceTree = SOURCE_ROOT; };
 		DCC0C34F130349C300EC45D2 /* XMPPElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPElement.m; path = ../../../../../Core/XMPPElement.m; sourceTree = SOURCE_ROOT; };
@@ -433,8 +433,8 @@
 				56F8385714C7962300AF62B3 /* RFImageToDataTransformer.m */,
 				56F8385A14C7962300AF62B3 /* XMPPIDTracker.h */,
 				56F8385B14C7962300AF62B3 /* XMPPIDTracker.m */,
-				DCC0C344130349A600EC45D2 /* LibIDN.h */,
-				DCC0C345130349A600EC45D2 /* LibIDN.m */,
+				DCC0C344130349A600EC45D2 /* XMPPStringPrep.h */,
+				DCC0C345130349A600EC45D2 /* XMPPStringPrep.m */,
 				DCC0C342130349A600EC45D2 /* GCDMulticastDelegate.h */,
 				DCC0C343130349A600EC45D2 /* GCDMulticastDelegate.m */,
 				DCF3C1671367299200111BA3 /* XMPPSRVResolver.h */,
@@ -592,7 +592,7 @@
 				DCC0C33B1303496E00EC45D2 /* GCDAsyncSocket.m in Sources */,
 				DCC0C348130349A600EC45D2 /* DDList.m in Sources */,
 				DCC0C349130349A600EC45D2 /* GCDMulticastDelegate.m in Sources */,
-				DCC0C34A130349A600EC45D2 /* LibIDN.m in Sources */,
+				DCC0C34A130349A600EC45D2 /* XMPPStringPrep.m in Sources */,
 				DCC0C361130349C300EC45D2 /* XMPPElement.m in Sources */,
 				DCC0C362130349C300EC45D2 /* XMPPIQ.m in Sources */,
 				DCC0C363130349C300EC45D2 /* XMPPJID.m in Sources */,

--- a/Xcode/Testing/TestElementReceipt/TestElementReceipt.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestElementReceipt/TestElementReceipt.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		DCC890FB13EBF90C00CDAB56 /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890C213EBF90C00CDAB56 /* XMPPStream.m */; };
 		DCC890FC13EBF90C00CDAB56 /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890C513EBF90C00CDAB56 /* DDList.m */; };
 		DCC890FD13EBF90C00CDAB56 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890C713EBF90C00CDAB56 /* GCDMulticastDelegate.m */; };
-		DCC890FE13EBF90C00CDAB56 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890C913EBF90C00CDAB56 /* LibIDN.m */; };
+		DCC890FE13EBF90C00CDAB56 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890C913EBF90C00CDAB56 /* XMPPStringPrep.m */; };
 		DCC890FF13EBF90C00CDAB56 /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890CB13EBF90C00CDAB56 /* RFImageToDataTransformer.m */; };
 		DCC8910013EBF90C00CDAB56 /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890CD13EBF90C00CDAB56 /* XMPPIDTracker.m */; };
 		DCC8910113EBF90C00CDAB56 /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC890CF13EBF90C00CDAB56 /* XMPPSRVResolver.m */; };
@@ -104,8 +104,8 @@
 		DCC890C513EBF90C00CDAB56 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
 		DCC890C613EBF90C00CDAB56 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
 		DCC890C713EBF90C00CDAB56 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
-		DCC890C813EBF90C00CDAB56 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LibIDN.h; sourceTree = "<group>"; };
-		DCC890C913EBF90C00CDAB56 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LibIDN.m; sourceTree = "<group>"; };
+		DCC890C813EBF90C00CDAB56 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		DCC890C913EBF90C00CDAB56 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
 		DCC890CA13EBF90C00CDAB56 /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
 		DCC890CB13EBF90C00CDAB56 /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
 		DCC890CC13EBF90C00CDAB56 /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
@@ -340,8 +340,8 @@
 				DCC890C513EBF90C00CDAB56 /* DDList.m */,
 				DCC890C613EBF90C00CDAB56 /* GCDMulticastDelegate.h */,
 				DCC890C713EBF90C00CDAB56 /* GCDMulticastDelegate.m */,
-				DCC890C813EBF90C00CDAB56 /* LibIDN.h */,
-				DCC890C913EBF90C00CDAB56 /* LibIDN.m */,
+				DCC890C813EBF90C00CDAB56 /* XMPPStringPrep.h */,
+				DCC890C913EBF90C00CDAB56 /* XMPPStringPrep.m */,
 				DCC890CA13EBF90C00CDAB56 /* RFImageToDataTransformer.h */,
 				DCC890CB13EBF90C00CDAB56 /* RFImageToDataTransformer.m */,
 				DCC890CC13EBF90C00CDAB56 /* XMPPIDTracker.h */,
@@ -478,7 +478,7 @@
 				DCC890FB13EBF90C00CDAB56 /* XMPPStream.m in Sources */,
 				DCC890FC13EBF90C00CDAB56 /* DDList.m in Sources */,
 				DCC890FD13EBF90C00CDAB56 /* GCDMulticastDelegate.m in Sources */,
-				DCC890FE13EBF90C00CDAB56 /* LibIDN.m in Sources */,
+				DCC890FE13EBF90C00CDAB56 /* XMPPStringPrep.m in Sources */,
 				DCC890FF13EBF90C00CDAB56 /* RFImageToDataTransformer.m in Sources */,
 				DCC8910013EBF90C00CDAB56 /* XMPPIDTracker.m in Sources */,
 				DCC8910113EBF90C00CDAB56 /* XMPPSRVResolver.m in Sources */,

--- a/Xcode/Testing/TestJID/Desktop/TestJID.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestJID/Desktop/TestJID.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		DCD1908F1548E56200659E75 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD1908E1548E56200659E75 /* AppDelegate.m */; };
 		DCD190921548E56200659E75 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DCD190901548E56200659E75 /* MainMenu.xib */; };
 		DCD190C5154A1CE500659E75 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD190C4154A1CE500659E75 /* XMPPJID.m */; };
-		DCD190C8154A1CF400659E75 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD190C7154A1CF400659E75 /* LibIDN.m */; };
+		DCD190C8154A1CF400659E75 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD190C7154A1CF400659E75 /* XMPPStringPrep.m */; };
 		DCD190CF154A1CFD00659E75 /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DCD190CC154A1CFD00659E75 /* libidn.a */; };
 /* End PBXBuildFile section */
 
@@ -34,8 +34,8 @@
 		DCD190911548E56200659E75 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		DCD190C3154A1CE500659E75 /* XMPPJID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPJID.h; path = ../../../../Core/XMPPJID.h; sourceTree = "<group>"; };
 		DCD190C4154A1CE500659E75 /* XMPPJID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPJID.m; path = ../../../../Core/XMPPJID.m; sourceTree = "<group>"; };
-		DCD190C6154A1CF400659E75 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../../../Utilities/LibIDN.h; sourceTree = "<group>"; };
-		DCD190C7154A1CF400659E75 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../../../Utilities/LibIDN.m; sourceTree = "<group>"; };
+		DCD190C6154A1CF400659E75 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../../../Utilities/XMPPStringPrep.h; sourceTree = "<group>"; };
+		DCD190C7154A1CF400659E75 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../../../Utilities/XMPPStringPrep.m; sourceTree = "<group>"; };
 		DCD190CA154A1CFD00659E75 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "idn-int.h"; sourceTree = "<group>"; };
 		DCD190CC154A1CFD00659E75 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libidn.a; sourceTree = "<group>"; };
 		DCD190CD154A1CFD00659E75 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stringprep.h; sourceTree = "<group>"; };
@@ -144,8 +144,8 @@
 		DCD190C2154A1CD200659E75 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DCD190C6154A1CF400659E75 /* LibIDN.h */,
-				DCD190C7154A1CF400659E75 /* LibIDN.m */,
+				DCD190C6154A1CF400659E75 /* XMPPStringPrep.h */,
+				DCD190C7154A1CF400659E75 /* XMPPStringPrep.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -227,7 +227,7 @@
 				DCD190881548E56200659E75 /* main.m in Sources */,
 				DCD1908F1548E56200659E75 /* AppDelegate.m in Sources */,
 				DCD190C5154A1CE500659E75 /* XMPPJID.m in Sources */,
-				DCD190C8154A1CF400659E75 /* LibIDN.m in Sources */,
+				DCD190C8154A1CF400659E75 /* XMPPStringPrep.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xcode/Testing/TestJID/Mobile/TestJID.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestJID/Mobile/TestJID.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		DCD190EC154A1D4C00659E75 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD190EB154A1D4C00659E75 /* main.m */; };
 		DCD190F0154A1D4C00659E75 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD190EF154A1D4C00659E75 /* AppDelegate.m */; };
 		DCD19101154A1D8600659E75 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD19100154A1D8600659E75 /* XMPPJID.m */; };
-		DCD19104154A1D9200659E75 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD19103154A1D9200659E75 /* LibIDN.m */; };
+		DCD19104154A1D9200659E75 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD19103154A1D9200659E75 /* XMPPStringPrep.m */; };
 		DCD1910B154A1D9B00659E75 /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DCD19108154A1D9B00659E75 /* libidn.a */; };
 /* End PBXBuildFile section */
 
@@ -31,8 +31,8 @@
 		DCD190EF154A1D4C00659E75 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		DCD190FF154A1D8600659E75 /* XMPPJID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPJID.h; path = ../../../../Core/XMPPJID.h; sourceTree = "<group>"; };
 		DCD19100154A1D8600659E75 /* XMPPJID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPJID.m; path = ../../../../Core/XMPPJID.m; sourceTree = "<group>"; };
-		DCD19102154A1D9200659E75 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../../../Utilities/LibIDN.h; sourceTree = "<group>"; };
-		DCD19103154A1D9200659E75 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../../../Utilities/LibIDN.m; sourceTree = "<group>"; };
+		DCD19102154A1D9200659E75 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../../../Utilities/XMPPStringPrep.h; sourceTree = "<group>"; };
+		DCD19103154A1D9200659E75 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../../../Utilities/XMPPStringPrep.m; sourceTree = "<group>"; };
 		DCD19106154A1D9B00659E75 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "idn-int.h"; sourceTree = "<group>"; };
 		DCD19108154A1D9B00659E75 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libidn.a; sourceTree = "<group>"; };
 		DCD19109154A1D9B00659E75 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stringprep.h; sourceTree = "<group>"; };
@@ -123,8 +123,8 @@
 		DCD190FD154A1D7100659E75 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				DCD19102154A1D9200659E75 /* LibIDN.h */,
-				DCD19103154A1D9200659E75 /* LibIDN.m */,
+				DCD19102154A1D9200659E75 /* XMPPStringPrep.h */,
+				DCD19103154A1D9200659E75 /* XMPPStringPrep.m */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -213,7 +213,7 @@
 				DCD190EC154A1D4C00659E75 /* main.m in Sources */,
 				DCD190F0154A1D4C00659E75 /* AppDelegate.m in Sources */,
 				DCD19101154A1D8600659E75 /* XMPPJID.m in Sources */,
-				DCD19104154A1D9200659E75 /* LibIDN.m in Sources */,
+				DCD19104154A1D9200659E75 /* XMPPStringPrep.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xcode/iPhoneXMPP/iPhoneXMPP.xcodeproj/project.pbxproj
+++ b/Xcode/iPhoneXMPP/iPhoneXMPP.xcodeproj/project.pbxproj
@@ -71,7 +71,7 @@
 		DC373190139F07CC00A8407D /* NSNumber+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC37318C139F07CC00A8407D /* NSNumber+XMPP.m */; };
 		DC373191139F07CC00A8407D /* NSXMLElement+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC37318E139F07CC00A8407D /* NSXMLElement+XMPP.m */; };
 		DC488444134AEB06000F79C5 /* XMPPCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = DC488442134AEB06000F79C5 /* XMPPCoreDataStorage.m */; };
-		DC84BBC512440A6F0055A459 /* LibIDN.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BBC012440A6F0055A459 /* LibIDN.m */; };
+		DC84BBC512440A6F0055A459 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BBC012440A6F0055A459 /* XMPPStringPrep.m */; };
 		DC84BBDB12440A8E0055A459 /* XMPPElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BBCA12440A8E0055A459 /* XMPPElement.m */; };
 		DC84BBDC12440A8E0055A459 /* XMPPIQ.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BBCC12440A8E0055A459 /* XMPPIQ.m */; };
 		DC84BBDD12440A8E0055A459 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = DC84BBCE12440A8E0055A459 /* XMPPJID.m */; };
@@ -259,8 +259,8 @@
 		DC488443134AEB06000F79C5 /* XMPPCoreDataStorageProtected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCoreDataStorageProtected.h; sourceTree = "<group>"; };
 		DC84BBA212440A040055A459 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "idn-int.h"; path = "../../Vendor/libidn/idn-int.h"; sourceTree = SOURCE_ROOT; };
 		DC84BBA312440A040055A459 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stringprep.h; path = ../../Vendor/libidn/stringprep.h; sourceTree = SOURCE_ROOT; };
-		DC84BBBF12440A6F0055A459 /* LibIDN.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibIDN.h; path = ../../Utilities/LibIDN.h; sourceTree = SOURCE_ROOT; };
-		DC84BBC012440A6F0055A459 /* LibIDN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LibIDN.m; path = ../../Utilities/LibIDN.m; sourceTree = SOURCE_ROOT; };
+		DC84BBBF12440A6F0055A459 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStringPrep.h; path = ../../Utilities/XMPPStringPrep.h; sourceTree = SOURCE_ROOT; };
+		DC84BBC012440A6F0055A459 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStringPrep.m; path = ../../Utilities/XMPPStringPrep.m; sourceTree = SOURCE_ROOT; };
 		DC84BBC912440A8E0055A459 /* XMPPElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPElement.h; path = ../../Core/XMPPElement.h; sourceTree = SOURCE_ROOT; };
 		DC84BBCA12440A8E0055A459 /* XMPPElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPElement.m; path = ../../Core/XMPPElement.m; sourceTree = SOURCE_ROOT; };
 		DC84BBCB12440A8E0055A459 /* XMPPIQ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPIQ.h; path = ../../Core/XMPPIQ.h; sourceTree = SOURCE_ROOT; };
@@ -685,8 +685,8 @@
 				DCB4243E1353FFA000572C70 /* RFImageToDataTransformer.m */,
 				07AF189B134BC3370084D82A /* XMPPSRVResolver.h */,
 				07AF189C134BC3370084D82A /* XMPPSRVResolver.m */,
-				DC84BBBF12440A6F0055A459 /* LibIDN.h */,
-				DC84BBC012440A6F0055A459 /* LibIDN.m */,
+				DC84BBBF12440A6F0055A459 /* XMPPStringPrep.h */,
+				DC84BBC012440A6F0055A459 /* XMPPStringPrep.m */,
 				DCC0BEE91301CE3D00EC45D2 /* GCDMulticastDelegate.h */,
 				DCC0BEEA1301CE3D00EC45D2 /* GCDMulticastDelegate.m */,
 				DCC0BEE51301CE3D00EC45D2 /* DDList.h */,
@@ -1197,7 +1197,7 @@
 				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
 				1D3623260D0F684500981E51 /* iPhoneXMPPAppDelegate.m in Sources */,
 				28C286E10D94DF7D0034E888 /* RootViewController.m in Sources */,
-				DC84BBC512440A6F0055A459 /* LibIDN.m in Sources */,
+				DC84BBC512440A6F0055A459 /* XMPPStringPrep.m in Sources */,
 				DC84BBDB12440A8E0055A459 /* XMPPElement.m in Sources */,
 				DC84BBDC12440A8E0055A459 /* XMPPIQ.m in Sources */,
 				DC84BBDD12440A8E0055A459 /* XMPPJID.m in Sources */,


### PR DESCRIPTION
This commit doesn't fix the licensing problem with LibIDN, but rather signals an intention to convert the functionality to a license more compatible with the rest of the project. It'll be easy to plug in the new functionality without a further name change.
