### PR TITLE
CopyWithZone within the XMPPPresence

### DIFF
--- a/Core/XMPPPresence.m
+++ b/Core/XMPPPresence.m
@@ -132,5 +132,10 @@
 	return [[self type] isEqualToString:@"error"];
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+    NSXMLElement *element = [super copyWithZone:zone];
+    return [[self class] presenceFromElement:element];
+}
 
 @end


### PR DESCRIPTION
Hi,

Here is a little fix for a bug that has been annoying for me:
The XMPPPresence didn't implement the copyWithZone. So, the returned object of the 'copy' method was a XMPPElement which thrown 'unrecognized selector' exceptions on the XMPPPresence methods.

Cheers,
Romain
