### PR TITLE
registerWithAttributes

### DIFF
--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -382,13 +382,14 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
  * If there is something immediately wrong, such as the stream is not connected,
  * this method will return NO and set the error.
  * 
+ * The attributes parameter is optional - you may pass nil.
  * The errPtr parameter is optional - you may pass nil.
- * 
+ *
  * Security Note:
  * The password will be sent in the clear unless the stream has been secured.
 **/
 - (BOOL)supportsInBandRegistration;
-- (BOOL)registerWithPassword:(NSString *)password error:(NSError **)errPtr;
+- (BOOL)registerWithPassword:(NSString *)password attributes:(NSDictionary *)attributes error:(NSError **)errPtr;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Authentication

--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -1595,7 +1595,7 @@ enum XMPPStreamConfig
  * 
  * If the XMPPStream is not connected, or the server doesn't support in-band registration, this method does nothing.
 **/
-- (BOOL)registerWithPassword:(NSString *)password error:(NSError **)errPtr
+- (BOOL)registerWithPassword:(NSString *)password attributes:(NSDictionary *)attributes error:(NSError **)errPtr
 {
 	XMPPLogTrace();
 	
@@ -1642,6 +1642,9 @@ enum XMPPStreamConfig
 		NSXMLElement *queryElement = [NSXMLElement elementWithName:@"query" xmlns:@"jabber:iq:register"];
 		[queryElement addChild:[NSXMLElement elementWithName:@"username" stringValue:username]];
 		[queryElement addChild:[NSXMLElement elementWithName:@"password" stringValue:password]];
+        if (attributes != nil)
+            for (NSString *key in attributes)
+                [queryElement addChild:[NSXMLElement elementWithName:key stringValue:[attributes objectForKey:key]]];
 		
 		NSXMLElement *iqElement = [NSXMLElement elementWithName:@"iq"];
 		[iqElement addAttributeWithName:@"type" stringValue:@"set"];


### PR DESCRIPTION
Add attributes parameter for additional registration info (for example: email). 

XEP-0077: In-Band Registration
Ref: http://xmpp.org/extensions/xep-0077.html

<iq type='set' id='reg2'>
  <query xmlns='jabber:iq:register'>
    <username>bill</username>
    <password>Calliope</password>
    <email>bard@shakespeare.lit</email>
  </query>
</iq>
