### PR TITLE
Functionality for handling chat room subject messages

### DIFF
--- a/Extensions/XEP-0045/XMPPMessage+XEP0045.h
+++ b/Extensions/XEP-0045/XMPPMessage+XEP0045.h
@@ -6,5 +6,9 @@
 
 - (BOOL)isGroupChatMessage;
 - (BOOL)isGroupChatMessageWithBody;
+- (BOOL)isGroupChatMessageWithSubject;
+
+- (NSString *)subject;
+- (void)addSubject:(NSString *)subject;
 
 @end

--- a/Extensions/XEP-0045/XMPPMessage+XEP0045.m
+++ b/Extensions/XEP-0045/XMPPMessage+XEP0045.m
@@ -21,4 +21,26 @@
 	return NO;
 }
 
+- (BOOL)isGroupChatMessageWithSubject
+{
+    if ([self isGroupChatMessage]) {
+        NSString *subject = [[self elementForName:@"subject"] stringValue];
+
+		return ((subject != nil) && ([subject length] > 0));
+    }
+
+    return NO;
+}
+
+- (NSString *)subject
+{
+	return [[self elementForName:@"subject"] stringValue];
+}
+
+- (void)addSubject:(NSString *)subject
+{
+    NSXMLElement *subjectElement = [NSXMLElement elementWithName:@"subject" stringValue:subject];
+    [self addChild:subjectElement];
+}
+
 @end

--- a/Extensions/XEP-0045/XMPPRoom.m
+++ b/Extensions/XEP-0045/XMPPRoom.m
@@ -1073,6 +1073,10 @@ enum XMPPRoomState
 		[xmppRoomStorage handleIncomingMessage:message room:self];
 		[multicastDelegate xmppRoom:self didReceiveMessage:message fromOccupant:from];
 	}
+    else if ([message isGroupChatMessageWithSubject])
+    {
+        roomSubject = [message subject];
+    }
 	else
 	{
 		// Todo... Handle other types of messages.


### PR DESCRIPTION
Hi Robbie!

First off, thanks very much for putting this project together! I've been using it for a small pet project I've been playing with and it's working out great!

I wanted to be able to read some info out of chat room subjects and found that there was a bit of functionality missing there, so I've added a few bits to support grabbing those subjects off of incoming messages.

Here's my commit comment:
XEP-0045: added methods to XMPPMessage category to handle room subjects, have XMPPRoom check incoming messages for room subjects and use them to set the roomSubject property

Let me know what you think! Thanks again!

-matt johnson
