### PR TITLE
Saves to managedObjectContext after XMPPFrameworks receives unavailable ...

### DIFF
--- a/Extensions/Roster/CoreDataStorage/XMPPUserCoreDataStorageObject.m
+++ b/Extensions/Roster/CoreDataStorage/XMPPUserCoreDataStorageObject.m
@@ -315,6 +315,8 @@
 		{
 			[self removeResourcesObject:resource];
 			[[self managedObjectContext] deleteObject:resource];
+			[[self managedObjectContext] save:nil];
+
 		}
 	}
 	else


### PR DESCRIPTION
...presence. 

Users would not go offline while using XMPPRoster and a Core Data Store. Adding this change fixes the issue for me. 
