### PR TITLE
Fix some XEP-0060 pub sub messages are malformed.

### DIFF
--- a/Extensions/XEP-0060/XMPPPubSub.m
+++ b/Extensions/XEP-0060/XMPPPubSub.m
@@ -491,11 +491,7 @@
 		
 		[x addChild:field];
 	}];
-	
-	NSXMLElement *optionsStanza = [NSXMLElement elementWithName:@"options"];
-	[optionsStanza addChild:x];
-	
-	return optionsStanza;
+	return x;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The formForOptions method in Extensions/XEP-0060/XMPPPubSub.m is creating a proper form options but always wrapping it with an options element. It is quite clear from the calls to this method that the expected result is the x element.

There are 5 uses which require the x element to be a child of different elements:
- Node subscription options, x should be child of an options element
- Subscription configuration, x should be child of an options element as well.
- Node creation options, x should be child of a configure element, this was malformed. This line shows that the intention was to put x under configure but the formForOptions method was returning the wrong thing:
  NSXMLElement *x = [self formForOptions:options withFromType:XMLNS_PUBSUB_NODE_CONFIG];
- Node configuration options, same as the previous one.
- Publish node options, in this case the x element should be under publish-options. Again the intention was ok but the formForOptions returned the wrong thing.
  NSXMLElement *x = [self formForOptions:options withFromType:XMLNS_PUBSUB_PUBLISH_OPTIONS];
