### PR TITLE
Fix #208 PubSub module doesn't trigger didReceiveMessage on PEP messages...

### DIFF
--- a/Extensions/XEP-0060/XMPPPubSub.m
+++ b/Extensions/XEP-0060/XMPPPubSub.m
@@ -405,7 +405,7 @@
 		if (![serviceJID isEqualToJID:[message from]]) return;
 	}
 	else {
-		if (![myJID isEqualToJID:[message from] options:XMPPJIDCompareBare]) return;
+		if ([myJID isEqualToJID:[message from] options:XMPPJIDCompareBare]) return;
 	}
 	
 	// <message from='pubsub.foo.co.uk' to='admin@foo.co.uk'>


### PR DESCRIPTION
As the issue says, when receiving a PEP message didReceiveMessage is not called as "from" is not equal to to the users JID. The proper behavior is exactly the opposite, we are not interested in our own events.
