### PR TITLE
added explicitly set locale on NSDateFormatters to bypass Apple bug.

### DIFF
--- a/Extensions/XEP-0082/XMPPDateTimeProfiles.m
+++ b/Extensions/XEP-0082/XMPPDateTimeProfiles.m
@@ -45,6 +45,7 @@
 	
 	NSDateFormatter *df = [[NSDateFormatter alloc] init];
 	[df setFormatterBehavior:NSDateFormatterBehavior10_4]; // Use unicode patterns (as opposed to 10_3)
+	[df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]]; //Bypass NSDateFormatter locale bug
 	[df setDateFormat:@"yyyy-MM-dd"];
 	
 	NSDate *result = [df dateFromString:dateStr];
@@ -84,6 +85,7 @@
 	
 	NSDateFormatter *df = [[NSDateFormatter alloc] init];
 	[df setFormatterBehavior:NSDateFormatterBehavior10_4]; // Use unicode patterns (as opposed to 10_3)
+	[df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]]; //Bypass NSDateFormatter locale bug
 	[df setDateFormat:@"yyyy-MM-dd"];
 	
 	NSString *today = [df stringFromDate:[NSDate date]];
@@ -187,6 +189,7 @@
 	
 	NSDateFormatter *df = [[NSDateFormatter alloc] init];
 	[df setFormatterBehavior:NSDateFormatterBehavior10_4]; // Use unicode patterns (as opposed to 10_3)
+	[df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]]; //Bypass NSDateFormatter locale bug
 	[df setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
 
 	NSDate *result = nil;


### PR DESCRIPTION
There is a know NSDateFormatter bug the causes date parse to fail on this document in some cases. The bug happens in some cases when the user sets a different locale other than 'en_US'. The bug causes NSDateFormatter to expect an am/pm even when sent to parse 24hr strings. This is easily solved by explicitly setting the locale of the NSDateFormatter.
