### PR TITLE
When language is nil retrieve the <body> element with no xml:lang attribute

### DIFF
--- a/Core/XMPPMessage.m
+++ b/Core/XMPPMessage.m
@@ -165,19 +165,29 @@
 
 - (NSString *)bodyForLanguage:(NSString *)language
 {
-    if ([language length] == 0)
-    {
-        return [self body];
-    }
+    // When language is nil retrieve the <body> element with no xml:lang attribute
+    BOOL noLanguage = [language length] == 0;
     
     NSString *bodyForLanguage = nil;
     
     for (NSXMLElement *bodyElement in [self elementsForName:@"body"])
     {
-        if ([language isEqualToString:[[bodyElement attributeForName:@"xml:lang"] stringValue]])
+        NSXMLNode *langAttr = [bodyElement attributeForName:@"xml:lang"];
+        if (noLanguage)
         {
-            bodyForLanguage = [bodyElement stringValue];
-            break;
+            if (langAttr == nil)
+            {
+                bodyForLanguage = [bodyElement stringValue];
+                break;
+            }
+        }
+        else
+        {
+            if ([language isEqualToString:[langAttr stringValue]])
+            {
+                bodyForLanguage = [bodyElement stringValue];
+                break;
+            }
         }
     }
     


### PR DESCRIPTION
ObjColumnist,

your formatting changed the meaning of the code.

I expected `- (NSString *)bodyForLanguage:(NSString *)language` to return the `<body>` element with no `xml:lang` attribute, whereas your code retrieves the first body, possibly missing the correct one (for instance, the message contains `<body xml:lang="fr">Bonjour</body><body>Hello</body>` and I am not able to retrieve the second body which is the default one).
