### PR TITLE
Sync with https://github.com/robbiehanson/CocoaAsyncSocket and a little tweak to handle Ignite Openfire behaviour

### DIFF
--- a/Core/XMPPMessage.m
+++ b/Core/XMPPMessage.m
@@ -170,6 +170,8 @@
     for (NSXMLElement *bodyElement in [self elementsForName:@"body"])
     {
         NSString *lang = [[bodyElement attributeForName:@"xml:lang"] stringValue];
+        if (lang == nil)
+            lang = [[bodyElement attributeForName:@"lang"] stringValue];
         
         if ([language isEqualToString:lang] || ([language length] == 0  && [lang length] == 0))
         {

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.m
@@ -6689,6 +6689,9 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 
 #if TARGET_OS_IPHONE
 
++ (void)ignore:(id)_
+{}
+
 + (void)startCFStreamThreadIfNeeded
 {
 	static dispatch_once_t predicate;
@@ -6711,7 +6714,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	// So we'll just create a timer that will never fire - unless the server runs for decades.
 	[NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
 	                                 target:self
-	                               selector:@selector(doNothingAtAll:)
+	                               selector:@selector(ignore:)
 	                               userInfo:nil
 	                                repeats:YES];
 	


### PR DESCRIPTION
Openfire server strips namespace 'xml' from 'xml:lang', so check for 'xml:lang' and 'lang' attributes when a body with a specific language is requested.

Removed warning from GCDAsyncSocket as it was already done in https://github.com/robbiehanson/CocoaAsyncSocket.
