### PR TITLE
Initial XEP-0198 support

### DIFF
--- a/Core/XMPP.h
+++ b/Core/XMPP.h
@@ -27,3 +27,7 @@
 // 
 
 #import "NSXMLElement+XMPP.h"
+
+// Stream Management
+#import "XMPPStreamManagement.h"
+

--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -278,6 +278,17 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
 **/
 - (BOOL)isConnected;
 
+
+
+- (BOOL)isStreamManagementSupported;
+
+@property (nonatomic, assign) BOOL streamManagementEnabled;
+@property (nonatomic, strong) NSString *sessionId;
+
+@property (readonly) UInt64 numberOfStanzasSent;
+@property UInt64 numberOfStanzasReceived;
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Connect & Disconnect
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -984,6 +995,10 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
  * adding any specific featues the delegate might support.
 **/
 - (void)xmppStream:(XMPPStream *)sender willSendP2PFeatures:(NSXMLElement *)streamFeatures;
+
+- (BOOL)xmppStream:(XMPPStream *)sender didReceiveStreamManagementElement:(NSXMLElement *)element;
+
+- (void)xmppStream:(XMPPStream *)sender didStreamManagementEnabled:(NSXMLElement *)element;
 
 /**
  * These methods are called as xmpp modules are registered and unregistered with the stream.

--- a/Extensions/Roster/XMPPRoster.m
+++ b/Extensions/Roster/XMPPRoster.m
@@ -923,6 +923,11 @@ enum XMPPRosterFlags
 	// This method is invoked on the moduleQueue.
 	
 	XMPPLogTrace();
+
+	if (sender.sessionId != nil) {
+		// save roster state for resuming session
+		return;
+	}
 	
     if([self autoClearAllUsersAndResources])
     {

--- a/Extensions/XEP-0198/XMPPStreamManagement.h
+++ b/Extensions/XEP-0198/XMPPStreamManagement.h
@@ -1,0 +1,14 @@
+//
+//  XMPPStream+StreamManagement.h
+//  iPhoneXMPP
+//
+//  Created by Vitaly on 03.03.14.
+//
+//
+#import "XMPP.h"
+
+@interface XMPPStreamManagement : XMPPModule<XMPPStreamDelegate>
+
+@property(nonatomic, assign) BOOL allowResumeSession;
+
+@end

--- a/Extensions/XEP-0198/XMPPStreamManagement.m
+++ b/Extensions/XEP-0198/XMPPStreamManagement.m
@@ -1,0 +1,39 @@
+//
+//  XMPPStream+StreamManagement.m
+//  iPhoneXMPP
+//
+//  Created by Vitaly on 03.03.14.
+//
+//
+
+#import "XMPPStreamManagement.h"
+
+#import "XMPP.h"
+#import "XMPPInternal.h"
+#import "XMPPLogging.h"
+#import "NSData+XMPP.h"
+#import "NSXMLElement+XMPP.h"
+
+
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+// Log levels: off, error, warn, info, verbose
+#if DEBUG
+static const int xmppLogLevel = XMPP_LOG_LEVEL_INFO; // | XMPP_LOG_FLAG_TRACE;
+#else
+static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
+#endif
+
+@implementation XMPPStreamManagement
+
+-(void) xmppStreamDidAuthenticate:(XMPPStream *)sender {
+    if ([sender isStreamManagementSupported]) {
+        XMPPElement *enable = [[XMPPElement alloc] initWithName:@"enable" xmlns:@"urn:xmpp:sm:3"];
+        [enable addAttributeWithName:@"resume" stringValue:[self allowResumeSession] ? @"true" : @"false"];
+        [sender sendElement:enable];
+    }
+}
+
+@end


### PR DESCRIPTION
What is done:
- [Basic acking scenario](http://xmpp.org/extensions/xep-0198.html#scenarios-basic) - acks and error handling
- [Resumption](http://xmpp.org/extensions/xep-0198.html#resumption)
- XMPPStreamManagement module (but most logic done in XMPPStream.m, is it possible to move something in extension module?)
- XMPPRoster module modified not to reset roster on disconnect when stream management enabled
- Session data (Session ID and packet counters) saved and restored from NSUserDefaults (Will it make problems with multiple XMPPStreams application?)

TODO:
- [Efficient acking scenario](http://xmpp.org/extensions/xep-0198.html#scenarios-efficient)
