### PR TITLE
Removed unnecessary code and logging.

### DIFF
--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -68,31 +68,6 @@
 	return self;
 }
 
-- (BOOL)activate:(XMPPStream *)aXmppStream
-{
-	XMPPLogTrace();
-	
-	if ([super activate:aXmppStream])
-	{
-		XMPPLogVerbose(@"%@: Activated", THIS_FILE);
-		
-		// Reserved for future potential use
-		
-		return YES;
-	}
-	
-	return NO;
-}
-
-- (void)deactivate
-{
-	XMPPLogTrace();
-	
-	// Reserved for future potential use
-	
-	[super deactivate];
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Properties
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
XMPPMessageArchiving is the only extension which writes to the debug log that it is activated itself. I find this very annoying in the log, since when I want to check which plugins got activated I would use the delegate method and I don't want a plugin to do the logging itself. (Especially since you (nearly) can't disable it when using CocoaPods.)
