### PR TITLE
Added a stored, thread safe NSDateFormatter

### DIFF
--- a/Extensions/XEP-0082/XMPPDateTimeProfiles.m
+++ b/Extensions/XEP-0082/XMPPDateTimeProfiles.m
@@ -5,6 +5,8 @@
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
+static NSString * const kXEP0082SharedDateFormatterKey = @"xep0082_shared_date_formatter_key";
+
 @interface XMPPDateTimeProfiles (PrivateAPI)
 + (NSDate *)parseDateTime:(NSString *)dateTimeStr withMandatoryTimeZone:(BOOL)mandatoryTZ;
 @end
@@ -43,7 +45,7 @@
 	// 
 	// 1776-07-04
 	
-	NSDateFormatter *df = [[NSDateFormatter alloc] init];
+	NSDateFormatter *df = [self threadDateFormatter];
 	[df setFormatterBehavior:NSDateFormatterBehavior10_4]; // Use unicode patterns (as opposed to 10_3)
 	[df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]]; //Bypass NSDateFormatter locale bug
 	[df setDateFormat:@"yyyy-MM-dd"];
@@ -83,7 +85,7 @@
 	// For example, -0800 instead of the current -0700.
 	// This can be rather confusing when printing the result.
 	
-	NSDateFormatter *df = [[NSDateFormatter alloc] init];
+	NSDateFormatter *df = [self threadDateFormatter];
 	[df setFormatterBehavior:NSDateFormatterBehavior10_4]; // Use unicode patterns (as opposed to 10_3)
 	[df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]]; //Bypass NSDateFormatter locale bug
 	[df setDateFormat:@"yyyy-MM-dd"];
@@ -187,7 +189,7 @@
 	
 	if (mandatoryTZ && !hasTimeZoneInfo) return nil;
 	
-	NSDateFormatter *df = [[NSDateFormatter alloc] init];
+	NSDateFormatter *df = [self threadDateFormatter];
 	[df setFormatterBehavior:NSDateFormatterBehavior10_4]; // Use unicode patterns (as opposed to 10_3)
 	[df setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US"]]; //Bypass NSDateFormatter locale bug
 	[df setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss"];
@@ -277,6 +279,17 @@
 	}
 	
 	return [NSTimeZone timeZoneForSecondsFromGMT:secondsOffset];
+}
+
++ (NSDateFormatter *)threadDateFormatter {
+  NSMutableDictionary *currentThreadStorage = [[NSThread currentThread] threadDictionary];
+  NSDateFormatter *sharedDateFormatter = currentThreadStorage[kXEP0082SharedDateFormatterKey];
+  if (!sharedDateFormatter) {
+    sharedDateFormatter = [NSDateFormatter new];
+    currentThreadStorage[kXEP0082SharedDateFormatterKey] = sharedDateFormatter;
+  }
+  
+  return sharedDateFormatter;
 }
 
 @end


### PR DESCRIPTION
Instead of creating a new, expensive NSDateFormatter every time one is needed, I created a stored, thread safe formatter to use inside the class.  
