### PR TITLE
NSFetchedResultsController predicate updating

### DIFF
--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
@@ -747,6 +747,11 @@ static NSMutableSet *databaseFileNames;
 		XMPPLogVerbose(@"%@: %@ - Merging changes into mainThreadManagedObjectContext", THIS_FILE, THIS_METHOD);
 		
 		dispatch_async(dispatch_get_main_queue(), ^{
+            
+            // http://stackoverflow.com/questions/3923826/nsfetchedresultscontroller-with-predicate-ignores-changes-merged-from-different
+            for (NSManagedObject *object in [[notification userInfo] objectForKey:NSUpdatedObjectsKey]) {
+                [[mainThreadManagedObjectContext objectWithID:[object objectID]] willAccessValueForKey:nil];
+            }
 			
 			[mainThreadManagedObjectContext mergeChangesFromContextDidSaveNotification:notification];
 			[self mainThreadManagedObjectContextDidMergeChanges];


### PR DESCRIPTION
When using a NSFetchedResultsController with a predicate that excludes items, the items won't be included in the NSFetchedResultsController even if they are updated to no longer be excluded.

An example from our app: We use a NSFetchedResultsController to power the users' contacts table view but don't want to display users who we don't have a subscription to. So our predicate says subscription != "none", which excludes those users from the NSFetchedResultsController. The problem happens when one of those users accepts a request, at which point they should be shown on the list but since they were previously excluded from the fetch request, they won't be added.
