### PR TITLE
SCRAM-SHA-1 implementation using wrong stringprep profile when normalizing passwords

### DIFF
--- a/Authentication/SCRAM-SHA-1/XMPPSCRAMSHA1Authentication.m
+++ b/Authentication/SCRAM-SHA-1/XMPPSCRAMSHA1Authentication.m
@@ -68,7 +68,7 @@ static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
     if ((self = [super init])) {
         xmppStream = stream;
         self.username = [XMPPStringPrep prepNode:[xmppStream.myJID user]];
-        self.password = [XMPPStringPrep prepResource:password];
+        self.password = [XMPPStringPrep prepPassword:password];
         self.hashAlgorithm = kCCHmacAlgSHA1;
     }
     return self;

--- a/Utilities/XMPPStringPrep.h
+++ b/Utilities/XMPPStringPrep.h
@@ -7,7 +7,7 @@
  * Preps a node identifier for use in a JID.
  * If the given node is invalid, this method returns nil.
  *
- * See the XMPP RFC (3920) for details.
+ * See the XMPP RFC (6120) for details.
  * 
  * Note: The prep properly converts the string to lowercase, as per the RFC.
 **/
@@ -17,7 +17,7 @@
  * Preps a domain name for use in a JID.
  * If the given domain is invalid, this method returns nil.
  * 
- * See the XMPP RFC (3920) for details.
+ * See the XMPP RFC (6120) for details.
 **/
 + (NSString *)prepDomain:(NSString *)domain;
 
@@ -25,8 +25,17 @@
  * Preps a resource identifier for use in a JID.
  * If the given node is invalid, this method returns nil.
  *
- * See the XMPP RFC (3920) for details.
+ * See the XMPP RFC (6120) for details.
  **/
 + (NSString *)prepResource:(NSString *)resource;
+
+/**
+ * Preps a password with SASLprep profile.
+ * If the given string is invalid, this method returns nil.
+ *
+ * See the SCRAM RFC (5802) for details.
+ **/
+
++ (NSString *) prepPassword:(NSString *)password;
 
 @end

--- a/Utilities/XMPPStringPrep.m
+++ b/Utilities/XMPPStringPrep.m
@@ -49,4 +49,19 @@
 	return [NSString stringWithUTF8String:buf];
 }
 
++ (NSString *)prepPassword:(NSString *)password
+{
+	if(password == nil) return nil;
+	
+	// Each allowable portion of a JID MUST NOT be more than 1023 bytes in length.
+	// We make the buffer just big enough to hold a null-terminated string of this length.
+	char buf[1024];
+	
+	strncpy(buf, [password UTF8String], sizeof(buf));
+	
+	if(stringprep(buf, sizeof(buf), 0, stringprep_saslprep) != 0) return nil;
+	
+	return [NSString stringWithUTF8String:buf];
+}
+
 @end


### PR DESCRIPTION
As defined in RFC5802 - http://tools.ietf.org/html/rfc5802#section-2.2 - password should be normalized with "SASLprep" profile (RFC4032) of the "stringprep" algorithm(RFC3454)
