### PR TITLE
Fixed change nickname may cause occupants duplicated issue

### DIFF
--- a/Extensions/XEP-0045/XMPPRoom.h
+++ b/Extensions/XEP-0045/XMPPRoom.h
@@ -31,6 +31,7 @@ static NSString *const XMPPMUCOwnerNamespace = @"http://jabber.org/protocol/muc#
 	
 	__strong XMPPJID *myRoomJID;
 	__strong NSString *myNickname;
+	__strong NSString *myOldNickname;
 	
 	__strong NSString *roomSubject;
 	

--- a/Extensions/XEP-0045/XMPPRoom.m
+++ b/Extensions/XEP-0045/XMPPRoom.m
@@ -479,6 +479,7 @@ enum XMPPRoomState
 
 - (void)changeNickname:(NSString *)newNickname
 {
+	myOldNickname = [myNickname copy];
 	myNickname = [newNickname copy];
     myRoomJID = [XMPPJID jidWithUser:[roomJID user] domain:[roomJID domain] resource:myNickname];
     XMPPPresence *presence = [XMPPPresence presenceWithType:nil to:myRoomJID];
@@ -981,7 +982,7 @@ enum XMPPRoomState
 	// Server's don't always properly send the statusCodes in every situation.
 	// So we have some extra checks to ensure the boolean variables are correct.
 	
-	if (didCreateRoom || isNicknameChange)
+	if (didCreateRoom)
 	{
 		isMyPresence = YES;
 	}
@@ -989,6 +990,13 @@ enum XMPPRoomState
 	{
 		if ([[from resource] isEqualToString:myNickname])
 			isMyPresence = YES;
+	}
+	if (!isMyPresence && isNicknameChange && myOldNickname)
+	{
+		if ([[from resource] isEqualToString:myOldNickname]) {
+			isMyPresence = YES;
+			myOldNickname = nil;
+		}
 	}
 	
 	XMPPLogVerbose(@"%@[%@] - isMyPresence = %@", THIS_FILE, roomJID, (isMyPresence ? @"YES" : @"NO"));
@@ -1006,11 +1014,11 @@ enum XMPPRoomState
 	
 	if (isMyPresence)
 	{
-		myRoomJID = from;
-		myNickname = [from resource];
-		
 		if (isAvailable)
 		{
+			myRoomJID = from;
+			myNickname = [from resource];
+            
 			if (state & kXMPPRoomStateJoining)
 			{
 				state &= ~kXMPPRoomStateJoining;


### PR DESCRIPTION
User A joined chatroom, then user B joined chatroom. If user A changed his nickname, it may cause duplicated occupants.

This is because the first unavailable presence has 303 status code but no 110 status code, then myRoomJID and myNickname will be update to old JID and nickname. 

Then the second available presence without 110 status code, and can't match wrong JID or nickname (L990 ~ L991). It will be treat as a normal occupant joins chatroom.

Tested on openfire 3.9.3. 
