### PR TITLE
remove unused header from imports in XMPPPing.m

### DIFF
--- a/Extensions/XEP-0199/XMPPPing.m
+++ b/Extensions/XEP-0199/XMPPPing.m
@@ -1,6 +1,5 @@
 #import "XMPPPing.h"
 #import "XMPPIDTracker.h"
-#import "XMPPFramework.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).


### PR DESCRIPTION
I'm wondering why it was placed here. `XMPPFramework.h` is optional user-space header with set of extension headers, isn't it?
