### PR TITLE
Updated XMPPMUC to include functionality for discovering rooms and services (issue #444)

### DIFF
--- a/Extensions/XEP-0045/XMPPMUC.h
+++ b/Extensions/XEP-0045/XMPPMUC.h
@@ -4,6 +4,8 @@
 
 #define _XMPP_MUC_H
 
+@class XMPPIDTracker;
+
 /**
  * The XMPPMUC module, combined with XMPPRoom and associated storage classes,
  * provides an implementation of XEP-0045 Multi-User Chat.
@@ -17,7 +19,6 @@
  *    and provides an efficient query to see if a presence or message element is targeted at a room.
  *  - It listens for MUC room invitations sent from other users.
 **/
-
 @interface XMPPMUC : XMPPModule
 {
 /*	Inherited from XMPPModule:
@@ -28,6 +29,8 @@
  */
 	
 	NSMutableSet *rooms;
+
+  XMPPIDTracker *xmppIDTracker;
 }
 
 /* Inherited from XMPPModule:
@@ -47,6 +50,27 @@
 - (BOOL)isMUCRoomPresence:(XMPPPresence *)presence;
 - (BOOL)isMUCRoomMessage:(XMPPMessage *)message;
 
+/**
+* This method will attempt to discover existing services for the domain found in xmppStream.myJID.
+*
+* @see xmppMUC:didDiscoverServices:
+* @see xmppMUCFailedToDiscoverServices:withError:
+*/
+- (void)discoverServices;
+
+/**
+* This method will attempt to discover existing rooms (that are not hidden) for a given service.
+*
+* @see xmppMUC:didDiscoverRooms:forServiceNamed:
+* @see xmppMUC:failedToDiscoverRoomsForServiceNamed:withError:
+*
+* @param serviceName The name of the service for which to discover rooms. Normally in the form
+*                    of "chat.shakespeare.lit".
+*
+* @return NO if a serviceName is not provided, otherwise YES
+*/
+- (BOOL)discoverRoomsForServiceNamed:(NSString *)serviceName;
+
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -56,7 +80,52 @@
 @protocol XMPPMUCDelegate
 @optional
 
-- (void)xmppMUC:(XMPPMUC *)sender roomJID:(XMPPJID *) roomJID didReceiveInvitation:(XMPPMessage *)message;
-- (void)xmppMUC:(XMPPMUC *)sender roomJID:(XMPPJID *) roomJID didReceiveInvitationDecline:(XMPPMessage *)message;
+- (void)xmppMUC:(XMPPMUC *)sender roomJID:(XMPPJID *)roomJID didReceiveInvitation:(XMPPMessage *)message;
+- (void)xmppMUC:(XMPPMUC *)sender roomJID:(XMPPJID *)roomJID didReceiveInvitationDecline:(XMPPMessage *)message;
+
+/**
+* Implement this method when calling [mucInstance discoverServices]. It will be invoked if the request
+* for discovering services is successfully executed and receives a successful response.
+*
+* @param sender XMPPMUC object invoking this delegate method.
+* @param services An array of NSXMLElements in the form shown below. You will need to extract the data you
+*                 wish to use.
+*
+*                 <item jid='chat.shakespeare.lit' name='Chatroom Service'/>
+*/
+- (void)xmppMUC:(XMPPMUC *)sender didDiscoverServices:(NSArray *)services;
+
+/**
+* Implement this method when calling [mucInstanse discoverServices]. It will be invoked if the request
+* for discovering services is unsuccessfully executed or receives an unsuccessful response.
+*
+* @param sender XMPPMUC object invoking this delegate method.
+* @param error NSError containing more details of the failure.
+*/
+- (void)xmppMUCFailedToDiscoverServices:(XMPPMUC *)sender withError:(NSError *)error;
+
+/**
+* Implement this method when calling [mucInstance discoverRoomsForServiceNamed:]. It will be invoked if
+* the request for discovering rooms is successfully executed and receives a successful response.
+*
+* @param sender XMPPMUC object invoking this delegate method.
+* @param rooms An array of NSXMLElements in the form shown below. You will need to extract the data you
+*              wish to use.
+*
+*              <item jid='forres@chat.shakespeare.lit' name='The Palace'/>
+*
+* @param serviceName The name of the service for which rooms were discovered.
+*/
+- (void)xmppMUC:(XMPPMUC *)sender didDiscoverRooms:(NSArray *)rooms forServiceNamed:(NSString *)serviceName;
+
+/**
+* Implement this method when calling [mucInstance discoverRoomsForServiceNamed:]. It will be invoked if
+* the request for discovering rooms is unsuccessfully executed or receives an unsuccessful response.
+*
+* @param sender XMPPMUC object invoking this delegate method.
+* @param serviceName The name of the service for which rooms were attempted to be discovered.
+* @param error NSError containing more details of the failure.
+*/
+- (void)xmppMUC:(XMPPMUC *)sender failedToDiscoverRoomsForServiceNamed:(NSString *)serviceName withError:(NSError *)error;
 
 @end


### PR DESCRIPTION
Added additional functionality to XMPPMUC for discovering a MUC service ([XEP-0045 6.1](http://xmpp.org/extensions/xep-0045.html#disco-service)) and discovering rooms ([XEP-0045 6.3](http://xmpp.org/extensions/xep-0045.html#disco-rooms)).

This should handle issue #444 that I created yesterday.
