### PR TITLE
Updated XEP-0077 to no longer use childCount == 0 as validation

### DIFF
--- a/Extensions/XEP-0077/XMPPRegistration.m
+++ b/Extensions/XEP-0077/XMPPRegistration.m
@@ -162,7 +162,7 @@ NSString *const XMPPRegistrationErrorDomain = @"XMPPRegistrationErrorDomain";
 
         NSString *type = [iq type];
 
-        if ([type isEqualToString:@"result"] && iq.childCount == 0) {
+        if ([type isEqualToString:@"result"]) {
           [multicastDelegate passwordChangeSuccessful:self];
         } else {
           // this should be impossible to reach, but just for safety's sake...
@@ -203,7 +203,7 @@ NSString *const XMPPRegistrationErrorDomain = @"XMPPRegistrationErrorDomain";
 
         NSString *type = [iq type];
 
-        if ([type isEqualToString:@"result"] && iq.childCount == 0) {
+        if ([type isEqualToString:@"result"]) {
           [multicastDelegate cancelRegistrationSuccessful:self];
         } else {
           // this should be impossible to reach, but just for safety's sake...
@@ -228,7 +228,6 @@ NSString *const XMPPRegistrationErrorDomain = @"XMPPRegistrationErrorDomain";
   NSString *type = [iq type];
 
   if ([type isEqualToString:@"result"] || [type isEqualToString:@"error"]) {
-    NSLog(@"invoking with iq: %@", iq);
     return [xmppIDTracker invokeForElement:iq withObject:iq];
   }
 


### PR DESCRIPTION
Based on the discussion [here](https://github.com/robbiehanson/XMPPFramework/commit/1cea8429b3c125c7af0187e26cdfb052159f9b29?diff=unified), using `childCount == 0` on [this line](https://github.com/robbiehanson/XMPPFramework/blob/master/Extensions/XEP-0077/XMPPRegistration.m#L165) and [this line](https://github.com/robbiehanson/XMPPFramework/blob/master/Extensions/XEP-0077/XMPPRegistration.m#L206) is a poor means of validation, since the code above is already checking for errors.

I also removed an `NSLog` statement.