### PR TITLE
Work from CocoaPods test jam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ xcuserdata
 .DS_Store
 project.xcworkspace
 .idea
+Xcode/Testing2/Pods
 

--- a/Extensions/XEP-0115/XMPPCapabilities.m
+++ b/Extensions/XEP-0115/XMPPCapabilities.m
@@ -496,7 +496,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 	return [str1 compare:str2 options:NSLiteralSearch];
 }
 
-- (NSString *)hashCapabilitiesFromQuery:(NSXMLElement *)query
++ (NSString *)hashCapabilitiesFromQuery:(NSXMLElement *)query
 {
 	if (query == nil) return nil;
 	
@@ -796,7 +796,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 	XMPPLogVerbose(@"%@: My capabilities:\n%@", THIS_FILE,
 				   [query XMLStringWithOptions:(NSXMLNodeCompactEmptyElement | NSXMLNodePrettyPrint)]);
 	
-	NSString *hash = [self hashCapabilitiesFromQuery:query];
+	NSString *hash = [self.class hashCapabilitiesFromQuery:query];
 	
 	if (hash == nil)
 	{
@@ -1258,7 +1258,7 @@ static NSInteger sortFieldValues(NSXMLElement *value1, NSXMLElement *value2, voi
 		
 		NSString *key = [self keyFromHash:hash algorithm:hashAlg];
 		
-		NSString *calculatedHash = [self hashCapabilitiesFromQuery:query];
+		NSString *calculatedHash = [self.class hashCapabilitiesFromQuery:query];
 		
 		if ([calculatedHash isEqualToString:hash])
 		{

--- a/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
+++ b/Vendor/CocoaAsyncSocket/GCDAsyncSocket.h
@@ -90,7 +90,11 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 #pragma mark Configuration
 
 @property (atomic, weak, readwrite) id delegate;
+#if OS_OBJECT_USE_OBJC
 @property (atomic, strong, readwrite) dispatch_queue_t delegateQueue;
+#else
+@property (atomic, assign, readwrite) dispatch_queue_t delegateQueue;
+#endif
 
 - (void)getDelegate:(id *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr;
 - (void)setDelegate:(id)delegate delegateQueue:(dispatch_queue_t)delegateQueue;

--- a/Xcode/Testing/AutoPingTest/Desktop/AutoPingTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoPingTest/Desktop/AutoPingTest.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		56F8388914C79AEB00AF62B3 /* XMPPAutoTime.m in Sources */ = {isa = PBXBuildFile; fileRef = 56F8388614C79AEB00AF62B3 /* XMPPAutoTime.m */; };
 		56F8388A14C79AEB00AF62B3 /* XMPPTime.m in Sources */ = {isa = PBXBuildFile; fileRef = 56F8388814C79AEB00AF62B3 /* XMPPTime.m */; };
+		9E8E5BBD1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E8E5BBC1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC17CD3E1355ED29007A32CC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC17CD3D1355ED29007A32CC /* Cocoa.framework */; };
 		DC17CD481355ED29007A32CC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DC17CD461355ED29007A32CC /* InfoPlist.strings */; };
 		DC17CD4B1355ED29007A32CC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DC17CD4A1355ED29007A32CC /* main.m */; };
@@ -60,6 +61,9 @@
 		56F8388614C79AEB00AF62B3 /* XMPPAutoTime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAutoTime.m; sourceTree = "<group>"; };
 		56F8388714C79AEB00AF62B3 /* XMPPTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPTime.h; sourceTree = "<group>"; };
 		56F8388814C79AEB00AF62B3 /* XMPPTime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPTime.m; sourceTree = "<group>"; };
+		9E8E5BB91AE2ADA900BE3E34 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9E8E5BBB1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9E8E5BBC1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC17CD391355ED29007A32CC /* AutoPingTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AutoPingTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC17CD3D1355ED29007A32CC /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		DC17CD401355ED29007A32CC /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -114,7 +118,7 @@
 		DC597EB114101FBF0050774C /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
 		DC597EB214101FBF0050774C /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
 		DC597EB314101FBF0050774C /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
-		DC597EB414101FBF0050774C /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		DC597EB414101FBF0050774C /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DC597EB514101FBF0050774C /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
 		DC597F0A14101FBF0050774C /* NSDate+XMPPDateTimeProfiles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+XMPPDateTimeProfiles.h"; sourceTree = "<group>"; };
 		DC597F0B14101FBF0050774C /* NSDate+XMPPDateTimeProfiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+XMPPDateTimeProfiles.m"; sourceTree = "<group>"; };
@@ -179,6 +183,15 @@
 				56F8388814C79AEB00AF62B3 /* XMPPTime.m */,
 			);
 			path = "XEP-0202";
+			sourceTree = "<group>";
+		};
+		9E8E5BBA1AE2ADD600BE3E34 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9E8E5BBB1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.h */,
+				9E8E5BBC1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
 			sourceTree = "<group>";
 		};
 		DC17CD2E1355ED29007A32CC = {
@@ -267,7 +280,9 @@
 				DC30E7D3153E0A88001B9E6D /* Deprecated-Plain */,
 				DC30E7D6153E0A88001B9E6D /* Digest-MD5 */,
 				DC30E7D9153E0A88001B9E6D /* Plain */,
+				9E8E5BBA1AE2ADD600BE3E34 /* SCRAM-SHA-1 */,
 				DC30E7DC153E0A88001B9E6D /* X-Facebook-Platform */,
+				9E8E5BB91AE2ADA900BE3E34 /* XMPPCustomBinding.h */,
 				DC30E7DF153E0A88001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -562,6 +577,7 @@
 				DC597F9E14101FBF0050774C /* DDLog.m in Sources */,
 				DC597F9F14101FBF0050774C /* DDTTYLogger.m in Sources */,
 				56F8388914C79AEB00AF62B3 /* XMPPAutoTime.m in Sources */,
+				9E8E5BBD1AE2ADD600BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				56F8388A14C79AEB00AF62B3 /* XMPPTime.m in Sources */,
 				DC30E7E0153E0A88001B9E6D /* XMPPAnonymousAuthentication.m in Sources */,
 				DC30E7E1153E0A88001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */,
@@ -615,7 +631,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -631,7 +647,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = macosx;
 			};
 			name = Release;

--- a/Xcode/Testing/AutoPingTest/Desktop/AutoPingTest/AutoPingTestAppDelegate.m
+++ b/Xcode/Testing/AutoPingTest/Desktop/AutoPingTest/AutoPingTestAppDelegate.m
@@ -44,7 +44,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 	
 	NSError *error = nil;
 	
-	if (![xmppStream connect:&error])
+	if (![xmppStream connectWithTimeout:XMPPStreamTimeoutNone error:&error])
 	{
 		DDLogError(@"%@: Error connecting: %@", [self class], error);
 	}

--- a/Xcode/Testing/AutoPingTest/Mobile/AutoPingTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoPingTest/Mobile/AutoPingTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9E8E5BC81AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E8E5BC71AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E328153DFD3E001B9E6D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC30E327153DFD3E001B9E6D /* Security.framework */; };
 		DC30E7FB153E0AA8001B9E6D /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E7EA153E0AA8001B9E6D /* XMPPAnonymousAuthentication.m */; };
 		DC30E7FC153E0AA8001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E7ED153E0AA8001B9E6D /* XMPPDeprecatedDigestAuthentication.m */; };
@@ -61,6 +62,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9E8E5BC41AE2AF9B00BE3E34 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9E8E5BC61AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9E8E5BC71AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E327153DFD3E001B9E6D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		DC30E7E9153E0AA8001B9E6D /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
 		DC30E7EA153E0AA8001B9E6D /* XMPPAnonymousAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAnonymousAuthentication.m; sourceTree = "<group>"; };
@@ -115,7 +119,7 @@
 		DC598113141033210050774C /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
 		DC598114141033210050774C /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
 		DC598115141033210050774C /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
-		DC598116141033210050774C /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		DC598116141033210050774C /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DC598117141033210050774C /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
 		DC59816C141033210050774C /* NSDate+XMPPDateTimeProfiles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+XMPPDateTimeProfiles.h"; sourceTree = "<group>"; };
 		DC59816D141033210050774C /* NSDate+XMPPDateTimeProfiles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+XMPPDateTimeProfiles.m"; sourceTree = "<group>"; };
@@ -184,6 +188,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9E8E5BC51AE2AF9B00BE3E34 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9E8E5BC61AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.h */,
+				9E8E5BC71AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
 		DC30E7E7153E0AA8001B9E6D /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,7 +205,9 @@
 				DC30E7EE153E0AA8001B9E6D /* Deprecated-Plain */,
 				DC30E7F1153E0AA8001B9E6D /* Digest-MD5 */,
 				DC30E7F4153E0AA8001B9E6D /* Plain */,
+				9E8E5BC51AE2AF9B00BE3E34 /* SCRAM-SHA-1 */,
 				DC30E7F7153E0AA8001B9E6D /* X-Facebook-Platform */,
+				9E8E5BC41AE2AF9B00BE3E34 /* XMPPCustomBinding.h */,
 				DC30E7FA153E0AA8001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -578,6 +593,7 @@
 				DC5981E8141033210050774C /* NSDate+XMPPDateTimeProfiles.m in Sources */,
 				DC5981E9141033210050774C /* XMPPDateTimeProfiles.m in Sources */,
 				DC5981F1141033210050774C /* XMPPAutoPing.m in Sources */,
+				9E8E5BC81AE2AF9B00BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DC5981F2141033210050774C /* XMPPPing.m in Sources */,
 				DC5981F6141033210050774C /* DDList.m in Sources */,
 				DC5981F7141033210050774C /* GCDMulticastDelegate.m in Sources */,
@@ -654,7 +670,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -672,7 +688,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/Xcode/Testing/AutoPingTest/Mobile/AutoPingTest/AutoPingTestAppDelegate.m
+++ b/Xcode/Testing/AutoPingTest/Mobile/AutoPingTest/AutoPingTestAppDelegate.m
@@ -38,7 +38,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 	
 	NSError *error = nil;
 	
-	if (![xmppStream connect:&error])
+	if (![xmppStream connectWithTimeout:XMPPStreamTimeoutNone error:&error])
 	{
 		DDLogError(@"%@: Error connecting: %@", [self class], error);
 	}

--- a/Xcode/Testing/AutoTimeTest/Desktop/AutoTimeTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoTimeTest/Desktop/AutoTimeTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9E8E5BD21AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E8E5BD11AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E513153DFFAD001B9E6D /* NSData+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E464153DFFAD001B9E6D /* NSData+XMPP.m */; };
 		DC30E514153DFFAD001B9E6D /* NSNumber+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E466153DFFAD001B9E6D /* NSNumber+XMPP.m */; };
 		DC30E515153DFFAD001B9E6D /* NSXMLElement+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E468153DFFAD001B9E6D /* NSXMLElement+XMPP.m */; };
@@ -30,10 +31,9 @@
 		DC30E529153DFFAD001B9E6D /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E49A153DFFAD001B9E6D /* DDFileLogger.m */; };
 		DC30E52A153DFFAD001B9E6D /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E49C153DFFAD001B9E6D /* DDLog.m */; };
 		DC30E52B153DFFAD001B9E6D /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E49E153DFFAD001B9E6D /* DDTTYLogger.m */; };
-		DC30E52C153DFFAD001B9E6D /* ContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E4A1153DFFAD001B9E6D /* ContextFilterLogFormatter.m */; };
-		DC30E52D153DFFAD001B9E6D /* DispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E4A3153DFFAD001B9E6D /* DispatchQueueLogFormatter.m */; };
+		DC30E52C153DFFAD001B9E6D /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E4A1153DFFAD001B9E6D /* DDContextFilterLogFormatter.m */; };
+		DC30E52D153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E4A3153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.m */; };
 		DC30E52E153DFFAD001B9E6D /* README.txt in Resources */ = {isa = PBXBuildFile; fileRef = DC30E4A4153DFFAD001B9E6D /* README.txt */; };
-		DC30E558153DFFAE001B9E6D /* libidn-1.24.tar.gz in Resources */ = {isa = PBXBuildFile; fileRef = DC30E505153DFFAD001B9E6D /* libidn-1.24.tar.gz */; };
 		DC30E559153DFFAE001B9E6D /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC30E506153DFFAD001B9E6D /* libidn.a */; };
 		DC30E56F153DFFE4001B9E6D /* NSDate+XMPPDateTimeProfiles.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E567153DFFE4001B9E6D /* NSDate+XMPPDateTimeProfiles.m */; };
 		DC30E570153DFFE4001B9E6D /* XMPPDateTimeProfiles.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E569153DFFE4001B9E6D /* XMPPDateTimeProfiles.m */; };
@@ -61,6 +61,9 @@
 		56F8342A14C76FA100AF62B3 /* XMPPAutoPing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAutoPing.m; sourceTree = "<group>"; };
 		56F8342B14C76FA100AF62B3 /* XMPPPing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPing.h; sourceTree = "<group>"; };
 		56F8342C14C76FA100AF62B3 /* XMPPPing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPing.m; sourceTree = "<group>"; };
+		9E8E5BCE1AE2B33300BE3E34 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9E8E5BD01AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9E8E5BD11AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E463153DFFAD001B9E6D /* NSData+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+XMPP.h"; sourceTree = "<group>"; };
 		DC30E464153DFFAD001B9E6D /* NSData+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+XMPP.m"; sourceTree = "<group>"; };
 		DC30E465153DFFAD001B9E6D /* NSNumber+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNumber+XMPP.h"; sourceTree = "<group>"; };
@@ -84,7 +87,7 @@
 		DC30E479153DFFAD001B9E6D /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
 		DC30E47A153DFFAD001B9E6D /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
 		DC30E47B153DFFAD001B9E6D /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
-		DC30E47C153DFFAD001B9E6D /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		DC30E47C153DFFAD001B9E6D /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DC30E47D153DFFAD001B9E6D /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
 		DC30E47F153DFFAD001B9E6D /* DDList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDList.h; sourceTree = "<group>"; };
 		DC30E480153DFFAD001B9E6D /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
@@ -110,10 +113,10 @@
 		DC30E49C153DFFAD001B9E6D /* DDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLog.m; sourceTree = "<group>"; };
 		DC30E49D153DFFAD001B9E6D /* DDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDTTYLogger.h; sourceTree = "<group>"; };
 		DC30E49E153DFFAD001B9E6D /* DDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDTTYLogger.m; sourceTree = "<group>"; };
-		DC30E4A0153DFFAD001B9E6D /* ContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		DC30E4A1153DFFAD001B9E6D /* ContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		DC30E4A2153DFFAD001B9E6D /* DispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		DC30E4A3153DFFAD001B9E6D /* DispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		DC30E4A0153DFFAD001B9E6D /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		DC30E4A1153DFFAD001B9E6D /* DDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		DC30E4A2153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		DC30E4A3153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
 		DC30E4A4153DFFAD001B9E6D /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
 		DC30E504153DFFAD001B9E6D /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "idn-int.h"; sourceTree = "<group>"; };
 		DC30E505153DFFAD001B9E6D /* libidn-1.24.tar.gz */ = {isa = PBXFileReference; lastKnownFileType = archive.gzip; path = "libidn-1.24.tar.gz"; sourceTree = "<group>"; };
@@ -182,6 +185,15 @@
 			);
 			name = "XEP-0199";
 			path = "../../../../../Extensions/XEP-0199";
+			sourceTree = "<group>";
+		};
+		9E8E5BCF1AE2B33300BE3E34 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9E8E5BD01AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.h */,
+				9E8E5BD11AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
 			sourceTree = "<group>";
 		};
 		DC30E461153DFF96001B9E6D /* XMPP */ = {
@@ -300,10 +312,10 @@
 		DC30E49F153DFFAD001B9E6D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				DC30E4A0153DFFAD001B9E6D /* ContextFilterLogFormatter.h */,
-				DC30E4A1153DFFAD001B9E6D /* ContextFilterLogFormatter.m */,
-				DC30E4A2153DFFAD001B9E6D /* DispatchQueueLogFormatter.h */,
-				DC30E4A3153DFFAD001B9E6D /* DispatchQueueLogFormatter.m */,
+				DC30E4A0153DFFAD001B9E6D /* DDContextFilterLogFormatter.h */,
+				DC30E4A1153DFFAD001B9E6D /* DDContextFilterLogFormatter.m */,
+				DC30E4A2153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.h */,
+				DC30E4A3153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.m */,
 				DC30E4A4153DFFAD001B9E6D /* README.txt */,
 			);
 			path = Extensions;
@@ -361,7 +373,9 @@
 				DC30E809153E0AD1001B9E6D /* Deprecated-Plain */,
 				DC30E80C153E0AD1001B9E6D /* Digest-MD5 */,
 				DC30E80F153E0AD1001B9E6D /* Plain */,
+				9E8E5BCF1AE2B33300BE3E34 /* SCRAM-SHA-1 */,
 				DC30E812153E0AD1001B9E6D /* X-Facebook-Platform */,
+				9E8E5BCE1AE2B33300BE3E34 /* XMPPCustomBinding.h */,
 				DC30E815153E0AD1001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -537,7 +551,6 @@
 				DC41733713F1D34800ED8D43 /* Credits.rtf in Resources */,
 				DC41733D13F1D34900ED8D43 /* MainMenu.xib in Resources */,
 				DC30E52E153DFFAD001B9E6D /* README.txt in Resources */,
-				DC30E558153DFFAE001B9E6D /* libidn-1.24.tar.gz in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -573,11 +586,12 @@
 				DC30E529153DFFAD001B9E6D /* DDFileLogger.m in Sources */,
 				DC30E52A153DFFAD001B9E6D /* DDLog.m in Sources */,
 				DC30E52B153DFFAD001B9E6D /* DDTTYLogger.m in Sources */,
-				DC30E52C153DFFAD001B9E6D /* ContextFilterLogFormatter.m in Sources */,
-				DC30E52D153DFFAD001B9E6D /* DispatchQueueLogFormatter.m in Sources */,
+				DC30E52C153DFFAD001B9E6D /* DDContextFilterLogFormatter.m in Sources */,
+				DC30E52D153DFFAD001B9E6D /* DDDispatchQueueLogFormatter.m in Sources */,
 				DC30E56F153DFFE4001B9E6D /* NSDate+XMPPDateTimeProfiles.m in Sources */,
 				DC30E570153DFFE4001B9E6D /* XMPPDateTimeProfiles.m in Sources */,
 				DC30E571153DFFE4001B9E6D /* XMPPAutoTime.m in Sources */,
+				9E8E5BD21AE2B33300BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DC30E572153DFFE4001B9E6D /* XMPPTime.m in Sources */,
 				DC30E816153E0AD1001B9E6D /* XMPPAnonymousAuthentication.m in Sources */,
 				DC30E817153E0AD1001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */,

--- a/Xcode/Testing/AutoTimeTest/Desktop/AutoTimeTest/AutoTimeTestAppDelegate.m
+++ b/Xcode/Testing/AutoTimeTest/Desktop/AutoTimeTest/AutoTimeTestAppDelegate.m
@@ -35,7 +35,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 	
 	NSError *error = nil;
 	
-	if (![xmppStream connect:&error])
+    if (![xmppStream connectWithTimeout: XMPPStreamTimeoutNone error:&error])
 	{
 		DDLogError(@"%@: Error connecting: %@", [self class], error);
 	}

--- a/Xcode/Testing/AutoTimeTest/Mobile/AutoTimeTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/AutoTimeTest/Mobile/AutoTimeTest.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		56F8345214C7733800AF62B3 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 56F8345114C7733800AF62B3 /* libiconv.dylib */; };
+		9E8E5BCD1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E8E5BCC1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E332153DFDF5001B9E6D /* AutoTimeTestAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E32D153DFDF5001B9E6D /* AutoTimeTestAppDelegate.m */; };
 		DC30E333153DFDF5001B9E6D /* AutoTimeTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E32F153DFDF5001B9E6D /* AutoTimeTestViewController.m */; };
 		DC30E334153DFDF5001B9E6D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E330153DFDF5001B9E6D /* main.m */; };
@@ -37,8 +38,8 @@
 		DC30E408153DFE52001B9E6D /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E379153DFE52001B9E6D /* DDFileLogger.m */; };
 		DC30E409153DFE52001B9E6D /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E37B153DFE52001B9E6D /* DDLog.m */; };
 		DC30E40A153DFE52001B9E6D /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E37D153DFE52001B9E6D /* DDTTYLogger.m */; };
-		DC30E40B153DFE52001B9E6D /* ContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E380153DFE52001B9E6D /* ContextFilterLogFormatter.m */; };
-		DC30E40C153DFE52001B9E6D /* DispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E382153DFE52001B9E6D /* DispatchQueueLogFormatter.m */; };
+		DC30E40B153DFE52001B9E6D /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E380153DFE52001B9E6D /* DDContextFilterLogFormatter.m */; };
+		DC30E40C153DFE52001B9E6D /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E382153DFE52001B9E6D /* DDDispatchQueueLogFormatter.m */; };
 		DC30E433153DFE52001B9E6D /* NSString+DDXML.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E3D8153DFE52001B9E6D /* NSString+DDXML.m */; };
 		DC30E434153DFE52001B9E6D /* DDXMLDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E3DB153DFE52001B9E6D /* DDXMLDocument.m */; };
 		DC30E435153DFE52001B9E6D /* DDXMLElement.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E3DD153DFE52001B9E6D /* DDXMLElement.m */; };
@@ -65,6 +66,9 @@
 
 /* Begin PBXFileReference section */
 		56F8345114C7733800AF62B3 /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
+		9E8E5BC91AE2B1C800BE3E34 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9E8E5BCB1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9E8E5BCC1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E32A153DFDF5001B9E6D /* AutoTimeTest-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "AutoTimeTest-Info.plist"; sourceTree = "<group>"; };
 		DC30E32B153DFDF5001B9E6D /* AutoTimeTest-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AutoTimeTest-Prefix.pch"; sourceTree = "<group>"; };
 		DC30E32C153DFDF5001B9E6D /* AutoTimeTestAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutoTimeTestAppDelegate.h; sourceTree = "<group>"; };
@@ -98,7 +102,7 @@
 		DC30E358153DFE52001B9E6D /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
 		DC30E359153DFE52001B9E6D /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
 		DC30E35A153DFE52001B9E6D /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
-		DC30E35B153DFE52001B9E6D /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		DC30E35B153DFE52001B9E6D /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DC30E35C153DFE52001B9E6D /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
 		DC30E35E153DFE52001B9E6D /* DDList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDList.h; sourceTree = "<group>"; };
 		DC30E35F153DFE52001B9E6D /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
@@ -124,10 +128,10 @@
 		DC30E37B153DFE52001B9E6D /* DDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLog.m; sourceTree = "<group>"; };
 		DC30E37C153DFE52001B9E6D /* DDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDTTYLogger.h; sourceTree = "<group>"; };
 		DC30E37D153DFE52001B9E6D /* DDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDTTYLogger.m; sourceTree = "<group>"; };
-		DC30E37F153DFE52001B9E6D /* ContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		DC30E380153DFE52001B9E6D /* ContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		DC30E381153DFE52001B9E6D /* DispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		DC30E382153DFE52001B9E6D /* DispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		DC30E37F153DFE52001B9E6D /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		DC30E380153DFE52001B9E6D /* DDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		DC30E381153DFE52001B9E6D /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		DC30E382153DFE52001B9E6D /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
 		DC30E383153DFE52001B9E6D /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
 		DC30E3D7153DFE52001B9E6D /* NSString+DDXML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+DDXML.h"; sourceTree = "<group>"; };
 		DC30E3D8153DFE52001B9E6D /* NSString+DDXML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+DDXML.m"; sourceTree = "<group>"; };
@@ -194,6 +198,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9E8E5BCA1AE2B1C800BE3E34 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9E8E5BCB1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.h */,
+				9E8E5BCC1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
 		DC30E335153DFE09001B9E6D /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -308,10 +321,10 @@
 		DC30E37E153DFE52001B9E6D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				DC30E37F153DFE52001B9E6D /* ContextFilterLogFormatter.h */,
-				DC30E380153DFE52001B9E6D /* ContextFilterLogFormatter.m */,
-				DC30E381153DFE52001B9E6D /* DispatchQueueLogFormatter.h */,
-				DC30E382153DFE52001B9E6D /* DispatchQueueLogFormatter.m */,
+				DC30E37F153DFE52001B9E6D /* DDContextFilterLogFormatter.h */,
+				DC30E380153DFE52001B9E6D /* DDContextFilterLogFormatter.m */,
+				DC30E381153DFE52001B9E6D /* DDDispatchQueueLogFormatter.h */,
+				DC30E382153DFE52001B9E6D /* DDDispatchQueueLogFormatter.m */,
 				DC30E383153DFE52001B9E6D /* README.txt */,
 			);
 			path = Extensions;
@@ -415,7 +428,9 @@
 				DC30E824153E0AF0001B9E6D /* Deprecated-Plain */,
 				DC30E827153E0AF0001B9E6D /* Digest-MD5 */,
 				DC30E82A153E0AF0001B9E6D /* Plain */,
+				9E8E5BCA1AE2B1C800BE3E34 /* SCRAM-SHA-1 */,
 				DC30E82D153E0AF0001B9E6D /* X-Facebook-Platform */,
+				9E8E5BC91AE2B1C800BE3E34 /* XMPPCustomBinding.h */,
 				DC30E830153E0AF0001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -603,6 +618,7 @@
 				DC30E3FD153DFE52001B9E6D /* DDList.m in Sources */,
 				DC30E3FE153DFE52001B9E6D /* GCDMulticastDelegate.m in Sources */,
 				DC30E3FF153DFE52001B9E6D /* XMPPStringPrep.m in Sources */,
+				9E8E5BCD1AE2B1C800BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DC30E400153DFE52001B9E6D /* RFImageToDataTransformer.m in Sources */,
 				DC30E402153DFE52001B9E6D /* XMPPIDTracker.m in Sources */,
 				DC30E403153DFE52001B9E6D /* XMPPSRVResolver.m in Sources */,
@@ -612,8 +628,8 @@
 				DC30E408153DFE52001B9E6D /* DDFileLogger.m in Sources */,
 				DC30E409153DFE52001B9E6D /* DDLog.m in Sources */,
 				DC30E40A153DFE52001B9E6D /* DDTTYLogger.m in Sources */,
-				DC30E40B153DFE52001B9E6D /* ContextFilterLogFormatter.m in Sources */,
-				DC30E40C153DFE52001B9E6D /* DispatchQueueLogFormatter.m in Sources */,
+				DC30E40B153DFE52001B9E6D /* DDContextFilterLogFormatter.m in Sources */,
+				DC30E40C153DFE52001B9E6D /* DDDispatchQueueLogFormatter.m in Sources */,
 				DC30E433153DFE52001B9E6D /* NSString+DDXML.m in Sources */,
 				DC30E434153DFE52001B9E6D /* DDXMLDocument.m in Sources */,
 				DC30E435153DFE52001B9E6D /* DDXMLElement.m in Sources */,
@@ -681,7 +697,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -699,7 +715,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/Xcode/Testing/AutoTimeTest/Mobile/AutoTimeTest/AutoTimeTestAppDelegate.m
+++ b/Xcode/Testing/AutoTimeTest/Mobile/AutoTimeTest/AutoTimeTestAppDelegate.m
@@ -37,7 +37,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 	
 	NSError *error = nil;
 	
-	if (![xmppStream connect:&error])
+    if (![xmppStream connectWithTimeout:XMPPStreamTimeoutNone error:&error])
 	{
 		DDLogError(@"%@: Error connecting: %@", [self class], error);
 	}

--- a/Xcode/Testing/FacebookTest/FacebookTest.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/FacebookTest/FacebookTest.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		4AB0D3B31746851500B4034A /* libfacebook_ios_sdk.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AB0D3B01746850500B4034A /* libfacebook_ios_sdk.a */; };
+		9E8E5BC21AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E8E5BC11AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.m */; };
+		9E8E5BD51AE2B54200BE3E34 /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E8E5BD31AE2B54200BE3E34 /* XMPPIDTracker.m */; };
 		DC30E5D3153E0204001B9E6D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC30E5D2153E0204001B9E6D /* Security.framework */; };
 		DC30E84D153E0B72001B9E6D /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E83C153E0B72001B9E6D /* XMPPAnonymousAuthentication.m */; };
 		DC30E84E153E0B72001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E83F153E0B72001B9E6D /* XMPPDeprecatedDigestAuthentication.m */; };
@@ -70,24 +72,15 @@
 			remoteGlobalIDString = D2AAC07D0554694100DB518D;
 			remoteInfo = "facebook-ios-sdk";
 		};
-		DC49313D17F8E0FA00402F77 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4AB0D3AB1746850500B4034A /* facebook-ios-sdk.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = B9CBC519152537270036AA71;
-			remoteInfo = FacebookSDKTests;
-		};
-		DC49313F17F8E0FA00402F77 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4AB0D3AB1746850500B4034A /* facebook-ios-sdk.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 85A44B9F16A8CE05007BE80E;
-			remoteInfo = FacebookSDKIntegrationTests;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		4AB0D3AB1746850500B4034A /* facebook-ios-sdk.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "facebook-ios-sdk.xcodeproj"; path = "facebook-ios-sdk/src/facebook-ios-sdk.xcodeproj"; sourceTree = "<group>"; };
+		9E8E5BBE1AE2AF2200BE3E34 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9E8E5BC01AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9E8E5BC11AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
+		9E8E5BD31AE2B54200BE3E34 /* XMPPIDTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPIDTracker.m; sourceTree = "<group>"; };
+		9E8E5BD41AE2B54200BE3E34 /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
 		DC0AC2A913490B3F00D053E3 /* XMPPInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPInternal.h; sourceTree = "<group>"; };
 		DC30E5D2153E0204001B9E6D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		DC30E83B153E0B72001B9E6D /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
@@ -210,10 +203,17 @@
 			isa = PBXGroup;
 			children = (
 				4AB0D3B01746850500B4034A /* libfacebook_ios_sdk.a */,
-				DC49313E17F8E0FA00402F77 /* FacebookSDKTests.octest */,
-				DC49314017F8E0FA00402F77 /* FacebookSDKIntegrationTests.octest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		9E8E5BBF1AE2AF2900BE3E34 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9E8E5BC01AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.h */,
+				9E8E5BC11AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
 			sourceTree = "<group>";
 		};
 		DC30E839153E0B72001B9E6D /* Authentication */ = {
@@ -224,7 +224,9 @@
 				DC30E840153E0B72001B9E6D /* Deprecated-Plain */,
 				DC30E843153E0B72001B9E6D /* Digest-MD5 */,
 				DC30E846153E0B72001B9E6D /* Plain */,
+				9E8E5BBF1AE2AF2900BE3E34 /* SCRAM-SHA-1 */,
 				DC30E849153E0B72001B9E6D /* X-Facebook-Platform */,
+				9E8E5BBE1AE2AF2200BE3E34 /* XMPPCustomBinding.h */,
 				DC30E84C153E0B72001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -343,6 +345,8 @@
 			children = (
 				DCC494CD1333043200F3C8F6 /* GCDMulticastDelegate.h */,
 				DCC494CE1333043200F3C8F6 /* GCDMulticastDelegate.m */,
+				9E8E5BD31AE2B54200BE3E34 /* XMPPIDTracker.m */,
+				9E8E5BD41AE2B54200BE3E34 /* XMPPIDTracker.h */,
 				DCC494CF1333043200F3C8F6 /* XMPPStringPrep.h */,
 				DCC494D01333043200F3C8F6 /* XMPPStringPrep.m */,
 				DCF3C1371367276900111BA3 /* XMPPSRVResolver.h */,
@@ -558,20 +562,6 @@
 			remoteRef = 4AB0D3AF1746850500B4034A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		DC49313E17F8E0FA00402F77 /* FacebookSDKTests.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = FacebookSDKTests.octest;
-			remoteRef = DC49313D17F8E0FA00402F77 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		DC49314017F8E0FA00402F77 /* FacebookSDKIntegrationTests.octest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = FacebookSDKIntegrationTests.octest;
-			remoteRef = DC49313F17F8E0FA00402F77 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -602,6 +592,7 @@
 				DCC494F61333043200F3C8F6 /* XMPPMessage.m in Sources */,
 				DCC494F71333043200F3C8F6 /* XMPPModule.m in Sources */,
 				DCC494F81333043200F3C8F6 /* XMPPParser.m in Sources */,
+				9E8E5BD51AE2B54200BE3E34 /* XMPPIDTracker.m in Sources */,
 				DCC494F91333043200F3C8F6 /* XMPPPresence.m in Sources */,
 				DCC494FB1333043200F3C8F6 /* XMPPStream.m in Sources */,
 				DCC494FC1333043200F3C8F6 /* DDList.m in Sources */,
@@ -623,6 +614,7 @@
 				DC30E84D153E0B72001B9E6D /* XMPPAnonymousAuthentication.m in Sources */,
 				DC30E84E153E0B72001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */,
 				DC30E84F153E0B72001B9E6D /* XMPPDeprecatedPlainAuthentication.m in Sources */,
+				9E8E5BC21AE2AF2900BE3E34 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DC30E850153E0B72001B9E6D /* XMPPDigestMD5Authentication.m in Sources */,
 				DC30E851153E0B72001B9E6D /* XMPPPlainAuthentication.m in Sources */,
 				DC30E852153E0B72001B9E6D /* XMPPXFacebookPlatformAuthentication.m in Sources */,
@@ -680,7 +672,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				OTHER_LDFLAGS = "-lxml2";
 				SDKROOT = iphoneos;
 			};
@@ -696,7 +688,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				OTHER_LDFLAGS = "-lxml2";
 				SDKROOT = iphoneos;

--- a/Xcode/Testing/MUCTesting/MUCTesting.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/MUCTesting/MUCTesting.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9EF4C51A1AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5191AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E868153E0BAC001B9E6D /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E857153E0BAC001B9E6D /* XMPPAnonymousAuthentication.m */; };
 		DC30E869153E0BAC001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E85A153E0BAC001B9E6D /* XMPPDeprecatedDigestAuthentication.m */; };
 		DC30E86A153E0BAC001B9E6D /* XMPPDeprecatedPlainAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E85D153E0BAC001B9E6D /* XMPPDeprecatedPlainAuthentication.m */; };
@@ -56,7 +57,7 @@
 		DCC8905E13EB611200CDAB56 /* XMPPAutoPing.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8904F13EB611200CDAB56 /* XMPPAutoPing.m */; };
 		DCC8905F13EB611200CDAB56 /* XMPPPing.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8905113EB611200CDAB56 /* XMPPPing.m */; };
 		DCC8906013EB611200CDAB56 /* XMPPTime.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8905413EB611200CDAB56 /* XMPPTime.m */; };
-		DCC8906113EB611200CDAB56 /* XMPPElement+Delay.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8905713EB611200CDAB56 /* XMPPElement+Delay.m */; };
+		DCC8906113EB611200CDAB56 /* NSXMLElement+XEP_0203.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8905713EB611200CDAB56 /* NSXMLElement+XEP_0203.m */; };
 		DCC8907113EB614500CDAB56 /* XMPPCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8906413EB614500CDAB56 /* XMPPCoreDataStorage.m */; };
 		DCC8907213EB614500CDAB56 /* XMPPCapabilities.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = DCC8906813EB614500CDAB56 /* XMPPCapabilities.xcdatamodel */; };
 		DCC8907313EB614500CDAB56 /* XMPPCapabilitiesCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC8906A13EB614500CDAB56 /* XMPPCapabilitiesCoreDataStorage.m */; };
@@ -68,6 +69,9 @@
 
 /* Begin PBXFileReference section */
 		56F834A414C7775F00AF62B3 /* XMPPFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPFramework.h; sourceTree = "<group>"; };
+		9EF4C5161AE2BA340019F001 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9EF4C5181AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9EF4C5191AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E856153E0BAC001B9E6D /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
 		DC30E857153E0BAC001B9E6D /* XMPPAnonymousAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAnonymousAuthentication.m; sourceTree = "<group>"; };
 		DC30E859153E0BAC001B9E6D /* XMPPDeprecatedDigestAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDeprecatedDigestAuthentication.h; sourceTree = "<group>"; };
@@ -117,7 +121,7 @@
 		DCC88FE313EB5D0B00CDAB56 /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
 		DCC88FE413EB5D0B00CDAB56 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
 		DCC88FE513EB5D0B00CDAB56 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
-		DCC88FE613EB5D0B00CDAB56 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		DCC88FE613EB5D0B00CDAB56 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DCC88FE713EB5D0B00CDAB56 /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
 		DCC88FE913EB5D0B00CDAB56 /* DDList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDList.h; sourceTree = "<group>"; };
 		DCC88FEA13EB5D0B00CDAB56 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
@@ -169,8 +173,8 @@
 		DCC8905113EB611200CDAB56 /* XMPPPing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPing.m; sourceTree = "<group>"; };
 		DCC8905313EB611200CDAB56 /* XMPPTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPTime.h; sourceTree = "<group>"; };
 		DCC8905413EB611200CDAB56 /* XMPPTime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPTime.m; sourceTree = "<group>"; };
-		DCC8905613EB611200CDAB56 /* XMPPElement+Delay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XMPPElement+Delay.h"; sourceTree = "<group>"; };
-		DCC8905713EB611200CDAB56 /* XMPPElement+Delay.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XMPPElement+Delay.m"; sourceTree = "<group>"; };
+		DCC8905613EB611200CDAB56 /* NSXMLElement+XEP_0203.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSXMLElement+XEP_0203.h"; sourceTree = "<group>"; };
+		DCC8905713EB611200CDAB56 /* NSXMLElement+XEP_0203.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSXMLElement+XEP_0203.m"; sourceTree = "<group>"; };
 		DCC8906313EB614500CDAB56 /* XMPPCoreDataStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCoreDataStorage.h; sourceTree = "<group>"; };
 		DCC8906413EB614500CDAB56 /* XMPPCoreDataStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPCoreDataStorage.m; sourceTree = "<group>"; };
 		DCC8906513EB614500CDAB56 /* XMPPCoreDataStorageProtected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCoreDataStorageProtected.h; sourceTree = "<group>"; };
@@ -204,6 +208,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9EF4C5171AE2BA340019F001 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5181AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.h */,
+				9EF4C5191AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
 		DC30E854153E0BAC001B9E6D /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
@@ -212,7 +225,9 @@
 				DC30E85B153E0BAC001B9E6D /* Deprecated-Plain */,
 				DC30E85E153E0BAC001B9E6D /* Digest-MD5 */,
 				DC30E861153E0BAC001B9E6D /* Plain */,
+				9EF4C5171AE2BA340019F001 /* SCRAM-SHA-1 */,
 				DC30E864153E0BAC001B9E6D /* X-Facebook-Platform */,
+				9EF4C5161AE2BA340019F001 /* XMPPCustomBinding.h */,
 				DC30E867153E0BAC001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -538,8 +553,8 @@
 		DCC8905513EB611200CDAB56 /* XEP-0203 */ = {
 			isa = PBXGroup;
 			children = (
-				DCC8905613EB611200CDAB56 /* XMPPElement+Delay.h */,
-				DCC8905713EB611200CDAB56 /* XMPPElement+Delay.m */,
+				DCC8905613EB611200CDAB56 /* NSXMLElement+XEP_0203.h */,
+				DCC8905713EB611200CDAB56 /* NSXMLElement+XEP_0203.m */,
 			);
 			name = "XEP-0203";
 			path = "../../../Extensions/XEP-0203";
@@ -678,12 +693,13 @@
 				DCC8905E13EB611200CDAB56 /* XMPPAutoPing.m in Sources */,
 				DCC8905F13EB611200CDAB56 /* XMPPPing.m in Sources */,
 				DCC8906013EB611200CDAB56 /* XMPPTime.m in Sources */,
-				DCC8906113EB611200CDAB56 /* XMPPElement+Delay.m in Sources */,
+				DCC8906113EB611200CDAB56 /* NSXMLElement+XEP_0203.m in Sources */,
 				DCC8907113EB614500CDAB56 /* XMPPCoreDataStorage.m in Sources */,
 				DCC8907213EB614500CDAB56 /* XMPPCapabilities.xcdatamodel in Sources */,
 				DCC8907313EB614500CDAB56 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
 				DCC8907413EB614500CDAB56 /* XMPPCapsCoreDataStorageObject.m in Sources */,
 				DCC8907513EB614500CDAB56 /* XMPPCapsResourceCoreDataStorageObject.m in Sources */,
+				9EF4C51A1AE2BA340019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DCC8907613EB614500CDAB56 /* XMPPCapabilities.m in Sources */,
 				DCC8911613EC072300CDAB56 /* XMPPAutoTime.m in Sources */,
 				DC30E868153E0BAC001B9E6D /* XMPPAnonymousAuthentication.m in Sources */,

--- a/Xcode/Testing/MUCTesting/MUCTesting/MUCTestingAppDelegate.m
+++ b/Xcode/Testing/MUCTesting/MUCTesting/MUCTestingAppDelegate.m
@@ -40,7 +40,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 	// Start connection process
 	
 	NSError *err = nil;
-	if (![xmppStream connect:&err])
+    if (![xmppStream connectWithTimeout: XMPPStreamTimeoutNone error:&err])
 	{
 		DDLogError(@"MUCTesting: Cannot connect: %@", err);
 	}

--- a/Xcode/Testing/TestCapabilitiesHashing/Mac/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestCapabilitiesHashing/Mac/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		9EF4C51F1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C51E1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E67F153E04B8001B9E6D /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC30E67E153E04B8001B9E6D /* libidn.a */; };
 		DC30E883153E0BF7001B9E6D /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E872153E0BF7001B9E6D /* XMPPAnonymousAuthentication.m */; };
 		DC30E884153E0BF7001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E875153E0BF7001B9E6D /* XMPPDeprecatedDigestAuthentication.m */; };
@@ -69,6 +70,9 @@
 		56F8384914C794BF00AF62B3 /* XMPPIDTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPIDTracker.m; path = ../../../../../Utilities/XMPPIDTracker.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* TestCapabilitiesHashing-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TestCapabilitiesHashing-Info.plist"; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* TestCapabilitiesHashing.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestCapabilitiesHashing.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9EF4C51B1AE2BAA60019F001 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9EF4C51D1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9EF4C51E1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E67E153E04B8001B9E6D /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidn.a; path = ../../../../../Vendor/libidn/libidn.a; sourceTree = "<group>"; };
 		DC30E871153E0BF7001B9E6D /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
 		DC30E872153E0BF7001B9E6D /* XMPPAnonymousAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAnonymousAuthentication.m; sourceTree = "<group>"; };
@@ -116,7 +120,7 @@
 		DCC0C231130340D200EC45D2 /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPParser.m; path = ../../../../../Core/XMPPParser.m; sourceTree = SOURCE_ROOT; };
 		DCC0C232130340D200EC45D2 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPPresence.h; path = ../../../../../Core/XMPPPresence.h; sourceTree = SOURCE_ROOT; };
 		DCC0C233130340D200EC45D2 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPresence.m; path = ../../../../../Core/XMPPPresence.m; sourceTree = SOURCE_ROOT; };
-		DCC0C234130340D200EC45D2 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStream.h; path = ../../../../../Core/XMPPStream.h; sourceTree = SOURCE_ROOT; };
+		DCC0C234130340D200EC45D2 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStream.h; path = ../../../../../Core/XMPPStream.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DCC0C235130340D200EC45D2 /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStream.m; path = ../../../../../Core/XMPPStream.m; sourceTree = SOURCE_ROOT; };
 		DCC0C2511303412E00EC45D2 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GCDAsyncSocket.h; path = ../../../../../Vendor/CocoaAsyncSocket/GCDAsyncSocket.h; sourceTree = SOURCE_ROOT; };
 		DCC0C2521303412E00EC45D2 /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GCDAsyncSocket.m; path = ../../../../../Vendor/CocoaAsyncSocket/GCDAsyncSocket.m; sourceTree = SOURCE_ROOT; };
@@ -242,6 +246,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9EF4C51C1AE2BAA60019F001 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C51D1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.h */,
+				9EF4C51E1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
 		DC30E86F153E0BF7001B9E6D /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
@@ -250,7 +263,9 @@
 				DC30E876153E0BF7001B9E6D /* Deprecated-Plain */,
 				DC30E879153E0BF7001B9E6D /* Digest-MD5 */,
 				DC30E87C153E0BF7001B9E6D /* Plain */,
+				9EF4C51C1AE2BAA60019F001 /* SCRAM-SHA-1 */,
 				DC30E87F153E0BF7001B9E6D /* X-Facebook-Platform */,
+				9EF4C51B1AE2BAA60019F001 /* XMPPCustomBinding.h */,
 				DC30E882153E0BF7001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -496,6 +511,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "TestCapabilitiesHashing" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;
@@ -552,6 +569,7 @@
 				DCC0C2631303418B00EC45D2 /* DDList.m in Sources */,
 				DCC0C2641303418B00EC45D2 /* XMPPStringPrep.m in Sources */,
 				DCC0C2E71303467700EC45D2 /* XMPPCapabilities.xcdatamodel in Sources */,
+				9EF4C51F1AE2BAA60019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DCC0C2E81303467700EC45D2 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
 				DCC0C2E91303467700EC45D2 /* XMPPCapsCoreDataStorageObject.m in Sources */,
 				DCC0C2EA1303467700EC45D2 /* XMPPCapsResourceCoreDataStorageObject.m in Sources */,
@@ -613,7 +631,6 @@
 					"\"$(SRCROOT)/../../../../../Vendor/libidn\"",
 				);
 				PRODUCT_NAME = TestCapabilitiesHashing;
-				SDKROOT = macosx10.7;
 			};
 			name = Debug;
 		};
@@ -634,7 +651,6 @@
 					"\"$(SRCROOT)/../../../../../Vendor/libidn\"",
 				);
 				PRODUCT_NAME = TestCapabilitiesHashing;
-				SDKROOT = macosx10.7;
 			};
 			name = Release;
 		};
@@ -650,7 +666,6 @@
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
 			};
 			name = Debug;
 		};
@@ -663,7 +678,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
 			};
 			name = Release;
 		};

--- a/Xcode/Testing/TestCapabilitiesHashing/iPhone/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestCapabilitiesHashing/iPhone/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		28D7ACF80DDB3853001CB0EB /* TestCapabilitiesHashingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 28D7ACF70DDB3853001CB0EB /* TestCapabilitiesHashingViewController.m */; };
 		56F8385F14C7962300AF62B3 /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 56F8385714C7962300AF62B3 /* RFImageToDataTransformer.m */; };
 		56F8386114C7962300AF62B3 /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 56F8385B14C7962300AF62B3 /* XMPPIDTracker.m */; };
+		9EF4C5241AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5231AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E682153E050B001B9E6D /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC30E681153E050B001B9E6D /* Security.framework */; };
 		DC30E684153E0531001B9E6D /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DC30E683153E0531001B9E6D /* libidn.a */; };
 		DC30E89E153E0C22001B9E6D /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E88D153E0C22001B9E6D /* XMPPAnonymousAuthentication.m */; };
@@ -79,6 +80,9 @@
 		56F8385A14C7962300AF62B3 /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPIDTracker.h; path = ../../../../../Utilities/XMPPIDTracker.h; sourceTree = "<group>"; };
 		56F8385B14C7962300AF62B3 /* XMPPIDTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPIDTracker.m; path = ../../../../../Utilities/XMPPIDTracker.m; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* TestCapabilitiesHashing-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "TestCapabilitiesHashing-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
+		9EF4C5201AE2BAB70019F001 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9EF4C5221AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9EF4C5231AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E681153E050B001B9E6D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		DC30E683153E0531001B9E6D /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidn.a; path = ../../../../../Vendor/libidn/libidn.a; sourceTree = "<group>"; };
 		DC30E88C153E0C22001B9E6D /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
@@ -142,7 +146,7 @@
 		DCC0C35A130349C300EC45D2 /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPParser.m; path = ../../../../../Core/XMPPParser.m; sourceTree = SOURCE_ROOT; };
 		DCC0C35B130349C300EC45D2 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPPresence.h; path = ../../../../../Core/XMPPPresence.h; sourceTree = SOURCE_ROOT; };
 		DCC0C35C130349C300EC45D2 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPresence.m; path = ../../../../../Core/XMPPPresence.m; sourceTree = SOURCE_ROOT; };
-		DCC0C35F130349C300EC45D2 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStream.h; path = ../../../../../Core/XMPPStream.h; sourceTree = SOURCE_ROOT; };
+		DCC0C35F130349C300EC45D2 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPStream.h; path = ../../../../../Core/XMPPStream.h; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DCC0C360130349C300EC45D2 /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPStream.m; path = ../../../../../Core/XMPPStream.m; sourceTree = SOURCE_ROOT; };
 		DCC0C36C13034A1000EC45D2 /* XMPPCapabilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPPCapabilities.h; path = "../../../../../Extensions/XEP-0115/XMPPCapabilities.h"; sourceTree = SOURCE_ROOT; };
 		DCC0C36D13034A1000EC45D2 /* XMPPCapabilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPCapabilities.m; path = "../../../../../Extensions/XEP-0115/XMPPCapabilities.m"; sourceTree = SOURCE_ROOT; };
@@ -253,6 +257,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9EF4C5211AE2BAB70019F001 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5221AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.h */,
+				9EF4C5231AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
 		DC30E88A153E0C22001B9E6D /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
@@ -261,7 +274,9 @@
 				DC30E891153E0C22001B9E6D /* Deprecated-Plain */,
 				DC30E894153E0C22001B9E6D /* Digest-MD5 */,
 				DC30E897153E0C22001B9E6D /* Plain */,
+				9EF4C5211AE2BAB70019F001 /* SCRAM-SHA-1 */,
 				DC30E89A153E0C22001B9E6D /* X-Facebook-Platform */,
+				9EF4C5201AE2BAB70019F001 /* XMPPCustomBinding.h */,
 				DC30E89D153E0C22001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -619,6 +634,7 @@
 				DC30E8A0153E0C22001B9E6D /* XMPPDeprecatedPlainAuthentication.m in Sources */,
 				DC30E8A1153E0C22001B9E6D /* XMPPDigestMD5Authentication.m in Sources */,
 				DC30E8A2153E0C22001B9E6D /* XMPPPlainAuthentication.m in Sources */,
+				9EF4C5241AE2BAB70019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DC30E8A3153E0C22001B9E6D /* XMPPXFacebookPlatformAuthentication.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Xcode/Testing/TestElementReceipt/TestElementReceipt.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestElementReceipt/TestElementReceipt.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9EF4C5291AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5281AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.m */; };
 		DC30E8B9153E0C42001B9E6D /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E8A8153E0C42001B9E6D /* XMPPAnonymousAuthentication.m */; };
 		DC30E8BA153E0C42001B9E6D /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E8AB153E0C42001B9E6D /* XMPPDeprecatedDigestAuthentication.m */; };
 		DC30E8BB153E0C42001B9E6D /* XMPPDeprecatedPlainAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = DC30E8AE153E0C42001B9E6D /* XMPPDeprecatedPlainAuthentication.m */; };
@@ -49,6 +50,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9EF4C5251AE2BC2F0019F001 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9EF4C5271AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9EF4C5281AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
 		DC30E8A7153E0C42001B9E6D /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
 		DC30E8A8153E0C42001B9E6D /* XMPPAnonymousAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAnonymousAuthentication.m; sourceTree = "<group>"; };
 		DC30E8AA153E0C42001B9E6D /* XMPPDeprecatedDigestAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDeprecatedDigestAuthentication.h; sourceTree = "<group>"; };
@@ -98,7 +102,7 @@
 		DCC890BE13EBF90C00CDAB56 /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
 		DCC890BF13EBF90C00CDAB56 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
 		DCC890C013EBF90C00CDAB56 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
-		DCC890C113EBF90C00CDAB56 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		DCC890C113EBF90C00CDAB56 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		DCC890C213EBF90C00CDAB56 /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
 		DCC890C413EBF90C00CDAB56 /* DDList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDList.h; sourceTree = "<group>"; };
 		DCC890C513EBF90C00CDAB56 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
@@ -148,6 +152,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9EF4C5261AE2BC2F0019F001 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5271AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.h */,
+				9EF4C5281AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
 		DC30E8A5153E0C42001B9E6D /* Authentication */ = {
 			isa = PBXGroup;
 			children = (
@@ -156,7 +169,9 @@
 				DC30E8AC153E0C42001B9E6D /* Deprecated-Plain */,
 				DC30E8AF153E0C42001B9E6D /* Digest-MD5 */,
 				DC30E8B2153E0C42001B9E6D /* Plain */,
+				9EF4C5261AE2BC2F0019F001 /* SCRAM-SHA-1 */,
 				DC30E8B5153E0C42001B9E6D /* X-Facebook-Platform */,
+				9EF4C5251AE2BC2F0019F001 /* XMPPCustomBinding.h */,
 				DC30E8B8153E0C42001B9E6D /* XMPPSASLAuthentication.h */,
 			);
 			name = Authentication;
@@ -463,6 +478,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9EF4C5291AE2BC2F0019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				DCC8909713EBF8EC00CDAB56 /* main.m in Sources */,
 				DCC8909E13EBF8EC00CDAB56 /* TestElementReceiptAppDelegate.m in Sources */,
 				DCC890F113EBF90C00CDAB56 /* NSData+XMPP.m in Sources */,

--- a/Xcode/Testing/TestIDTracker/TestIDTracker.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestIDTracker/TestIDTracker.xcodeproj/project.pbxproj
@@ -7,6 +7,34 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9EF4C5461AE2BCBC0019F001 /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C52E1AE2BCBC0019F001 /* XMPPAnonymousAuthentication.m */; };
+		9EF4C5471AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5311AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.m */; };
+		9EF4C5481AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5341AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.m */; };
+		9EF4C5491AE2BCBC0019F001 /* XMPPDigestMD5Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5371AE2BCBC0019F001 /* XMPPDigestMD5Authentication.m */; };
+		9EF4C54A1AE2BCBC0019F001 /* XMPPPlainAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C53A1AE2BCBC0019F001 /* XMPPPlainAuthentication.m */; };
+		9EF4C54B1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C53D1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.m */; };
+		9EF4C54C1AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5401AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.m */; };
+		9EF4C54D1AE2BCBC0019F001 /* XMPPXOAuth2Google.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5431AE2BCBC0019F001 /* XMPPXOAuth2Google.m */; };
+		9EF4C5511AE2BCD10019F001 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5501AE2BCD10019F001 /* GCDAsyncSocket.m */; };
+		9EF4C5571AE2BD4B0019F001 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5551AE2BD4B0019F001 /* GCDMulticastDelegate.m */; };
+		9EF4C56E1AE2BD660019F001 /* XMPPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C55B1AE2BD660019F001 /* XMPPConstants.m */; };
+		9EF4C56F1AE2BD660019F001 /* XMPPElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C55D1AE2BD660019F001 /* XMPPElement.m */; };
+		9EF4C5701AE2BD660019F001 /* XMPPIQ.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5601AE2BD660019F001 /* XMPPIQ.m */; };
+		9EF4C5711AE2BD660019F001 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5621AE2BD660019F001 /* XMPPJID.m */; };
+		9EF4C5721AE2BD660019F001 /* XMPPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5651AE2BD660019F001 /* XMPPMessage.m */; };
+		9EF4C5731AE2BD660019F001 /* XMPPModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5671AE2BD660019F001 /* XMPPModule.m */; };
+		9EF4C5741AE2BD660019F001 /* XMPPParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5691AE2BD660019F001 /* XMPPParser.m */; };
+		9EF4C5751AE2BD660019F001 /* XMPPPresence.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C56B1AE2BD660019F001 /* XMPPPresence.m */; };
+		9EF4C5761AE2BD660019F001 /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C56D1AE2BD660019F001 /* XMPPStream.m */; };
+		9EF4C57E1AE2BD870019F001 /* NSData+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5791AE2BD870019F001 /* NSData+XMPP.m */; };
+		9EF4C57F1AE2BD870019F001 /* NSNumber+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C57B1AE2BD870019F001 /* NSNumber+XMPP.m */; };
+		9EF4C5801AE2BD870019F001 /* NSXMLElement+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C57D1AE2BD870019F001 /* NSXMLElement+XMPP.m */; };
+		9EF4C5821AE2BDC90019F001 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C5811AE2BDC90019F001 /* libxml2.dylib */; };
+		9EF4C5851AE2BE4E0019F001 /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5831AE2BE4E0019F001 /* XMPPSRVResolver.m */; };
+		9EF4C5881AE2BE5C0019F001 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5861AE2BE5C0019F001 /* XMPPStringPrep.m */; };
+		9EF4C5911AE2BEBE0019F001 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C5901AE2BEBE0019F001 /* Security.framework */; };
+		9EF4C5931AE2BED70019F001 /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C5921AE2BED70019F001 /* libidn.a */; };
+		9EF4C5971AE2BF1C0019F001 /* libresolv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C5961AE2BF1C0019F001 /* libresolv.dylib */; };
 		DCC88A7B13E7770D00CDAB56 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC88A7A13E7770D00CDAB56 /* Cocoa.framework */; };
 		DCC88A8513E7770D00CDAB56 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DCC88A8313E7770D00CDAB56 /* InfoPlist.strings */; };
 		DCC88A8713E7770D00CDAB56 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC88A8613E7770D00CDAB56 /* main.m */; };
@@ -22,6 +50,67 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9EF4C52A1AE2BC9E0019F001 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XMPP.h; path = ../../../../Core/XMPP.h; sourceTree = "<group>"; };
+		9EF4C52D1AE2BCBC0019F001 /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
+		9EF4C52E1AE2BCBC0019F001 /* XMPPAnonymousAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAnonymousAuthentication.m; sourceTree = "<group>"; };
+		9EF4C5301AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDeprecatedDigestAuthentication.h; sourceTree = "<group>"; };
+		9EF4C5311AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPDeprecatedDigestAuthentication.m; sourceTree = "<group>"; };
+		9EF4C5331AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDeprecatedPlainAuthentication.h; sourceTree = "<group>"; };
+		9EF4C5341AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPDeprecatedPlainAuthentication.m; sourceTree = "<group>"; };
+		9EF4C5361AE2BCBC0019F001 /* XMPPDigestMD5Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDigestMD5Authentication.h; sourceTree = "<group>"; };
+		9EF4C5371AE2BCBC0019F001 /* XMPPDigestMD5Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPDigestMD5Authentication.m; sourceTree = "<group>"; };
+		9EF4C5391AE2BCBC0019F001 /* XMPPPlainAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPlainAuthentication.h; sourceTree = "<group>"; };
+		9EF4C53A1AE2BCBC0019F001 /* XMPPPlainAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPlainAuthentication.m; sourceTree = "<group>"; };
+		9EF4C53C1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9EF4C53D1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
+		9EF4C53F1AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPXFacebookPlatformAuthentication.h; sourceTree = "<group>"; };
+		9EF4C5401AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPXFacebookPlatformAuthentication.m; sourceTree = "<group>"; };
+		9EF4C5421AE2BCBC0019F001 /* XMPPXOAuth2Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPXOAuth2Google.h; sourceTree = "<group>"; };
+		9EF4C5431AE2BCBC0019F001 /* XMPPXOAuth2Google.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPXOAuth2Google.m; sourceTree = "<group>"; };
+		9EF4C5441AE2BCBC0019F001 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9EF4C5451AE2BCBC0019F001 /* XMPPSASLAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSASLAuthentication.h; sourceTree = "<group>"; };
+		9EF4C54F1AE2BCD10019F001 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncSocket.h; sourceTree = "<group>"; };
+		9EF4C5501AE2BCD10019F001 /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncSocket.m; sourceTree = "<group>"; };
+		9EF4C5551AE2BD4B0019F001 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
+		9EF4C5561AE2BD4B0019F001 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
+		9EF4C5591AE2BD660019F001 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPP.h; sourceTree = "<group>"; };
+		9EF4C55A1AE2BD660019F001 /* XMPPConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPConstants.h; sourceTree = "<group>"; };
+		9EF4C55B1AE2BD660019F001 /* XMPPConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPConstants.m; sourceTree = "<group>"; };
+		9EF4C55C1AE2BD660019F001 /* XMPPElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPElement.h; sourceTree = "<group>"; };
+		9EF4C55D1AE2BD660019F001 /* XMPPElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPElement.m; sourceTree = "<group>"; };
+		9EF4C55E1AE2BD660019F001 /* XMPPInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPInternal.h; sourceTree = "<group>"; };
+		9EF4C55F1AE2BD660019F001 /* XMPPIQ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIQ.h; sourceTree = "<group>"; };
+		9EF4C5601AE2BD660019F001 /* XMPPIQ.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPIQ.m; sourceTree = "<group>"; };
+		9EF4C5611AE2BD660019F001 /* XMPPJID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPJID.h; sourceTree = "<group>"; };
+		9EF4C5621AE2BD660019F001 /* XMPPJID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPJID.m; sourceTree = "<group>"; };
+		9EF4C5631AE2BD660019F001 /* XMPPLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPLogging.h; sourceTree = "<group>"; };
+		9EF4C5641AE2BD660019F001 /* XMPPMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPMessage.h; sourceTree = "<group>"; };
+		9EF4C5651AE2BD660019F001 /* XMPPMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPMessage.m; sourceTree = "<group>"; };
+		9EF4C5661AE2BD660019F001 /* XMPPModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPModule.h; sourceTree = "<group>"; };
+		9EF4C5671AE2BD660019F001 /* XMPPModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPModule.m; sourceTree = "<group>"; };
+		9EF4C5681AE2BD660019F001 /* XMPPParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPParser.h; sourceTree = "<group>"; };
+		9EF4C5691AE2BD660019F001 /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
+		9EF4C56A1AE2BD660019F001 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
+		9EF4C56B1AE2BD660019F001 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
+		9EF4C56C1AE2BD660019F001 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		9EF4C56D1AE2BD660019F001 /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
+		9EF4C5781AE2BD870019F001 /* NSData+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+XMPP.h"; sourceTree = "<group>"; };
+		9EF4C5791AE2BD870019F001 /* NSData+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+XMPP.m"; sourceTree = "<group>"; };
+		9EF4C57A1AE2BD870019F001 /* NSNumber+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNumber+XMPP.h"; sourceTree = "<group>"; };
+		9EF4C57B1AE2BD870019F001 /* NSNumber+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+XMPP.m"; sourceTree = "<group>"; };
+		9EF4C57C1AE2BD870019F001 /* NSXMLElement+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSXMLElement+XMPP.h"; sourceTree = "<group>"; };
+		9EF4C57D1AE2BD870019F001 /* NSXMLElement+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSXMLElement+XMPP.m"; sourceTree = "<group>"; };
+		9EF4C5811AE2BDC90019F001 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
+		9EF4C5831AE2BE4E0019F001 /* XMPPSRVResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSRVResolver.m; sourceTree = "<group>"; };
+		9EF4C5841AE2BE4E0019F001 /* XMPPSRVResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSRVResolver.h; sourceTree = "<group>"; };
+		9EF4C5861AE2BE5C0019F001 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
+		9EF4C5871AE2BE5C0019F001 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		9EF4C58B1AE2BE850019F001 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "idn-int.h"; sourceTree = "<group>"; };
+		9EF4C58D1AE2BE850019F001 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stringprep.h; sourceTree = "<group>"; };
+		9EF4C5901AE2BEBE0019F001 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		9EF4C5921AE2BED70019F001 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidn.a; path = ../../../Vendor/libidn/libidn.a; sourceTree = "<group>"; };
+		9EF4C5941AE2BEEA0019F001 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		9EF4C5961AE2BF1C0019F001 /* libresolv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libresolv.dylib; path = usr/lib/libresolv.dylib; sourceTree = SDKROOT; };
 		DCC88A7613E7770D00CDAB56 /* TestIDTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestIDTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCC88A7A13E7770D00CDAB56 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		DCC88A7D13E7770D00CDAB56 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -54,6 +143,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9EF4C5971AE2BF1C0019F001 /* libresolv.dylib in Frameworks */,
+				9EF4C5931AE2BED70019F001 /* libidn.a in Frameworks */,
+				9EF4C5911AE2BEBE0019F001 /* Security.framework in Frameworks */,
+				9EF4C5821AE2BDC90019F001 /* libxml2.dylib in Frameworks */,
 				DCC88A7B13E7770D00CDAB56 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -61,6 +154,189 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9EF4C52B1AE2BCBC0019F001 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C52C1AE2BCBC0019F001 /* Anonymous */,
+				9EF4C52F1AE2BCBC0019F001 /* Deprecated-Digest */,
+				9EF4C5321AE2BCBC0019F001 /* Deprecated-Plain */,
+				9EF4C5351AE2BCBC0019F001 /* Digest-MD5 */,
+				9EF4C5381AE2BCBC0019F001 /* Plain */,
+				9EF4C53B1AE2BCBC0019F001 /* SCRAM-SHA-1 */,
+				9EF4C53E1AE2BCBC0019F001 /* X-Facebook-Platform */,
+				9EF4C5411AE2BCBC0019F001 /* X-OAuth2-Google */,
+				9EF4C5441AE2BCBC0019F001 /* XMPPCustomBinding.h */,
+				9EF4C5451AE2BCBC0019F001 /* XMPPSASLAuthentication.h */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		9EF4C52C1AE2BCBC0019F001 /* Anonymous */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C52D1AE2BCBC0019F001 /* XMPPAnonymousAuthentication.h */,
+				9EF4C52E1AE2BCBC0019F001 /* XMPPAnonymousAuthentication.m */,
+			);
+			path = Anonymous;
+			sourceTree = "<group>";
+		};
+		9EF4C52F1AE2BCBC0019F001 /* Deprecated-Digest */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5301AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.h */,
+				9EF4C5311AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.m */,
+			);
+			path = "Deprecated-Digest";
+			sourceTree = "<group>";
+		};
+		9EF4C5321AE2BCBC0019F001 /* Deprecated-Plain */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5331AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.h */,
+				9EF4C5341AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.m */,
+			);
+			path = "Deprecated-Plain";
+			sourceTree = "<group>";
+		};
+		9EF4C5351AE2BCBC0019F001 /* Digest-MD5 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5361AE2BCBC0019F001 /* XMPPDigestMD5Authentication.h */,
+				9EF4C5371AE2BCBC0019F001 /* XMPPDigestMD5Authentication.m */,
+			);
+			path = "Digest-MD5";
+			sourceTree = "<group>";
+		};
+		9EF4C5381AE2BCBC0019F001 /* Plain */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5391AE2BCBC0019F001 /* XMPPPlainAuthentication.h */,
+				9EF4C53A1AE2BCBC0019F001 /* XMPPPlainAuthentication.m */,
+			);
+			path = Plain;
+			sourceTree = "<group>";
+		};
+		9EF4C53B1AE2BCBC0019F001 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C53C1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.h */,
+				9EF4C53D1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
+		9EF4C53E1AE2BCBC0019F001 /* X-Facebook-Platform */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C53F1AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.h */,
+				9EF4C5401AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.m */,
+			);
+			path = "X-Facebook-Platform";
+			sourceTree = "<group>";
+		};
+		9EF4C5411AE2BCBC0019F001 /* X-OAuth2-Google */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5421AE2BCBC0019F001 /* XMPPXOAuth2Google.h */,
+				9EF4C5431AE2BCBC0019F001 /* XMPPXOAuth2Google.m */,
+			);
+			path = "X-OAuth2-Google";
+			sourceTree = "<group>";
+		};
+		9EF4C54E1AE2BCD10019F001 /* CocoaAsyncSocket */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C54F1AE2BCD10019F001 /* GCDAsyncSocket.h */,
+				9EF4C5501AE2BCD10019F001 /* GCDAsyncSocket.m */,
+			);
+			path = CocoaAsyncSocket;
+			sourceTree = "<group>";
+		};
+		9EF4C5521AE2BCEC0019F001 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5891AE2BE850019F001 /* libidn */,
+				9EF4C54E1AE2BCD10019F001 /* CocoaAsyncSocket */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		9EF4C5531AE2BD240019F001 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5861AE2BE5C0019F001 /* XMPPStringPrep.m */,
+				9EF4C5871AE2BE5C0019F001 /* XMPPStringPrep.h */,
+				9EF4C5831AE2BE4E0019F001 /* XMPPSRVResolver.m */,
+				9EF4C5841AE2BE4E0019F001 /* XMPPSRVResolver.h */,
+				9EF4C5551AE2BD4B0019F001 /* GCDMulticastDelegate.m */,
+				9EF4C5561AE2BD4B0019F001 /* GCDMulticastDelegate.h */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		9EF4C5541AE2BD330019F001 /* XMPP */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5771AE2BD870019F001 /* Categories */,
+				9EF4C5581AE2BD660019F001 /* Core */,
+				9EF4C5531AE2BD240019F001 /* Utilities */,
+				9EF4C5521AE2BCEC0019F001 /* Vendor */,
+				9EF4C52B1AE2BCBC0019F001 /* Authentication */,
+			);
+			name = XMPP;
+			path = ../../../..;
+			sourceTree = "<group>";
+		};
+		9EF4C5581AE2BD660019F001 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5591AE2BD660019F001 /* XMPP.h */,
+				9EF4C55A1AE2BD660019F001 /* XMPPConstants.h */,
+				9EF4C55B1AE2BD660019F001 /* XMPPConstants.m */,
+				9EF4C55C1AE2BD660019F001 /* XMPPElement.h */,
+				9EF4C55D1AE2BD660019F001 /* XMPPElement.m */,
+				9EF4C55E1AE2BD660019F001 /* XMPPInternal.h */,
+				9EF4C55F1AE2BD660019F001 /* XMPPIQ.h */,
+				9EF4C5601AE2BD660019F001 /* XMPPIQ.m */,
+				9EF4C5611AE2BD660019F001 /* XMPPJID.h */,
+				9EF4C5621AE2BD660019F001 /* XMPPJID.m */,
+				9EF4C5631AE2BD660019F001 /* XMPPLogging.h */,
+				9EF4C5641AE2BD660019F001 /* XMPPMessage.h */,
+				9EF4C5651AE2BD660019F001 /* XMPPMessage.m */,
+				9EF4C5661AE2BD660019F001 /* XMPPModule.h */,
+				9EF4C5671AE2BD660019F001 /* XMPPModule.m */,
+				9EF4C5681AE2BD660019F001 /* XMPPParser.h */,
+				9EF4C5691AE2BD660019F001 /* XMPPParser.m */,
+				9EF4C56A1AE2BD660019F001 /* XMPPPresence.h */,
+				9EF4C56B1AE2BD660019F001 /* XMPPPresence.m */,
+				9EF4C56C1AE2BD660019F001 /* XMPPStream.h */,
+				9EF4C56D1AE2BD660019F001 /* XMPPStream.m */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		9EF4C5771AE2BD870019F001 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5781AE2BD870019F001 /* NSData+XMPP.h */,
+				9EF4C5791AE2BD870019F001 /* NSData+XMPP.m */,
+				9EF4C57A1AE2BD870019F001 /* NSNumber+XMPP.h */,
+				9EF4C57B1AE2BD870019F001 /* NSNumber+XMPP.m */,
+				9EF4C57C1AE2BD870019F001 /* NSXMLElement+XMPP.h */,
+				9EF4C57D1AE2BD870019F001 /* NSXMLElement+XMPP.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		9EF4C5891AE2BE850019F001 /* libidn */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C58B1AE2BE850019F001 /* idn-int.h */,
+				9EF4C58D1AE2BE850019F001 /* stringprep.h */,
+			);
+			path = libidn;
+			sourceTree = "<group>";
+		};
 		DCC88A6B13E7770D00CDAB56 = {
 			isa = PBXGroup;
 			children = (
@@ -82,6 +358,11 @@
 		DCC88A7913E7770D00CDAB56 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9EF4C5961AE2BF1C0019F001 /* libresolv.dylib */,
+				9EF4C5941AE2BEEA0019F001 /* CFNetwork.framework */,
+				9EF4C5921AE2BED70019F001 /* libidn.a */,
+				9EF4C5901AE2BEBE0019F001 /* Security.framework */,
+				9EF4C5811AE2BDC90019F001 /* libxml2.dylib */,
 				DCC88A7A13E7770D00CDAB56 /* Cocoa.framework */,
 				DCC88A7C13E7770D00CDAB56 /* Other Frameworks */,
 			);
@@ -101,6 +382,8 @@
 		DCC88A8013E7770D00CDAB56 /* TestIDTracker */ = {
 			isa = PBXGroup;
 			children = (
+				9EF4C5541AE2BD330019F001 /* XMPP */,
+				9EF4C52A1AE2BC9E0019F001 /* XMPP.h */,
 				DCC88A9713E7772900CDAB56 /* XMPPIDTracker.h */,
 				DCC88A9813E7772900CDAB56 /* XMPPIDTracker.m */,
 				DCC88A8C13E7770E00CDAB56 /* TestIDTrackerAppDelegate.h */,
@@ -204,13 +487,37 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9EF4C5701AE2BD660019F001 /* XMPPIQ.m in Sources */,
+				9EF4C5851AE2BE4E0019F001 /* XMPPSRVResolver.m in Sources */,
 				DCC88A8713E7770D00CDAB56 /* main.m in Sources */,
 				DCC88A8E13E7770E00CDAB56 /* TestIDTrackerAppDelegate.m in Sources */,
+				9EF4C57E1AE2BD870019F001 /* NSData+XMPP.m in Sources */,
+				9EF4C5741AE2BD660019F001 /* XMPPParser.m in Sources */,
 				DCC88A9913E7772900CDAB56 /* XMPPIDTracker.m in Sources */,
 				DCC88AA513E7817700CDAB56 /* DDAbstractDatabaseLogger.m in Sources */,
+				9EF4C56E1AE2BD660019F001 /* XMPPConstants.m in Sources */,
+				9EF4C5461AE2BCBC0019F001 /* XMPPAnonymousAuthentication.m in Sources */,
+				9EF4C5511AE2BCD10019F001 /* GCDAsyncSocket.m in Sources */,
 				DCC88AA613E7817700CDAB56 /* DDASLLogger.m in Sources */,
+				9EF4C5761AE2BD660019F001 /* XMPPStream.m in Sources */,
+				9EF4C54C1AE2BCBC0019F001 /* XMPPXFacebookPlatformAuthentication.m in Sources */,
+				9EF4C57F1AE2BD870019F001 /* NSNumber+XMPP.m in Sources */,
+				9EF4C5721AE2BD660019F001 /* XMPPMessage.m in Sources */,
+				9EF4C5481AE2BCBC0019F001 /* XMPPDeprecatedPlainAuthentication.m in Sources */,
+				9EF4C5491AE2BCBC0019F001 /* XMPPDigestMD5Authentication.m in Sources */,
+				9EF4C5711AE2BD660019F001 /* XMPPJID.m in Sources */,
+				9EF4C5751AE2BD660019F001 /* XMPPPresence.m in Sources */,
 				DCC88AA713E7817700CDAB56 /* DDFileLogger.m in Sources */,
+				9EF4C54A1AE2BCBC0019F001 /* XMPPPlainAuthentication.m in Sources */,
+				9EF4C54D1AE2BCBC0019F001 /* XMPPXOAuth2Google.m in Sources */,
+				9EF4C5471AE2BCBC0019F001 /* XMPPDeprecatedDigestAuthentication.m in Sources */,
+				9EF4C5731AE2BD660019F001 /* XMPPModule.m in Sources */,
+				9EF4C56F1AE2BD660019F001 /* XMPPElement.m in Sources */,
 				DCC88AA813E7817700CDAB56 /* DDLog.m in Sources */,
+				9EF4C54B1AE2BCBC0019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */,
+				9EF4C5571AE2BD4B0019F001 /* GCDMulticastDelegate.m in Sources */,
+				9EF4C5801AE2BD870019F001 /* NSXMLElement+XMPP.m in Sources */,
+				9EF4C5881AE2BE5C0019F001 /* XMPPStringPrep.m in Sources */,
 				DCC88AA913E7817700CDAB56 /* DDTTYLogger.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -265,6 +572,7 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -285,6 +593,7 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = /usr/include/libxml2;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				SDKROOT = macosx;
 			};
@@ -297,6 +606,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TestIDTracker/TestIDTracker-Prefix.pch";
 				INFOPLIST_FILE = "TestIDTracker/TestIDTracker-Info.plist";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/Users/pnm/code/XMPPFramework/Vendor/libidn,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -309,6 +622,10 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TestIDTracker/TestIDTracker-Prefix.pch";
 				INFOPLIST_FILE = "TestIDTracker/TestIDTracker-Info.plist";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/Users/pnm/code/XMPPFramework/Vendor/libidn,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/Xcode/Testing/TestXEP82/Mac/TestXEP82.xcodeproj/project.pbxproj
+++ b/Xcode/Testing/TestXEP82/Mac/TestXEP82.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "TestXEP82" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;
@@ -245,7 +247,6 @@
 				INFOPLIST_FILE = "TestXEP82-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = TestXEP82;
-				SDKROOT = macosx10.7;
 			};
 			name = Debug;
 		};
@@ -262,7 +263,6 @@
 				INFOPLIST_FILE = "TestXEP82-Info.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
 				PRODUCT_NAME = TestXEP82;
-				SDKROOT = macosx10.7;
 			};
 			name = Release;
 		};
@@ -277,7 +277,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
 			};
 			name = Debug;
 		};
@@ -289,7 +288,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
 			};
 			name = Release;
 		};

--- a/Xcode/Testing/XMPPTesting.xcworkspace/contents.xcworkspacedata
+++ b/Xcode/Testing/XMPPTesting.xcworkspace/contents.xcworkspacedata
@@ -23,7 +23,10 @@
       location = "group:FacebookTest/FacebookTest.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:MulticastDelegateTest/MulticastDelegateTest.xcodeproj">
+      location = "group:MulticastDelegateTest/Desktop/MulticastDelegateTest.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:MulticastDelegateTest/Mobile/MulticastDelegateTest.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:MUCTesting/MUCTesting.xcodeproj">

--- a/Xcode/Testing/XMPPTesting.xcworkspace/contents.xcworkspacedata
+++ b/Xcode/Testing/XMPPTesting.xcworkspace/contents.xcworkspacedata
@@ -44,6 +44,9 @@
       location = "group:TestCapabilitiesHashing/iPhone/TestCapabilitiesHashing/TestCapabilitiesHashing.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:TestDDList/TestDDList.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:TestElementReceipt/TestElementReceipt.xcodeproj">
    </FileRef>
    <FileRef
@@ -51,6 +54,12 @@
    </FileRef>
    <FileRef
       location = "group:TestSRVResolver/TestSRVResolver.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:TestJID/Mobile/TestJID.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:TestJID/Desktop/TestJID.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:TestXEP82/Mac/TestXEP82.xcodeproj">

--- a/Xcode/Testing2/Podfile
+++ b/Xcode/Testing2/Podfile
@@ -1,0 +1,13 @@
+xcodeproj 'XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj'
+
+# Uncomment this line to define a global platform for your project
+# platform :ios, '6.0'
+
+target 'XMPPFrameworkTests' do
+	
+end
+
+target 'XMPPFrameworkTestsTests' do
+	pod 'OCMock', '~> 3.1'
+end
+

--- a/Xcode/Testing2/XMPPFrameworkTests.xcworkspace/contents.xcworkspacedata
+++ b/Xcode/Testing2/XMPPFrameworkTests.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Xcode/Testing2/XMPPFrameworkTests.xcworkspace/xcshareddata/XMPPFrameworkTests.xccheckout
+++ b/Xcode/Testing2/XMPPFrameworkTests.xcworkspace/xcshareddata/XMPPFrameworkTests.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>027F606B-7E74-433B-B0DE-C179ACF6846D</string>
+	<key>IDESourceControlProjectName</key>
+	<string>XMPPFrameworkTests</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D</key>
+		<string>github.com:paulmelnikow/XMPPFramework.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>Xcode/Testing2/XMPPFrameworkTests.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D</key>
+		<string>../../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>github.com:paulmelnikow/XMPPFramework.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D</string>
+			<key>IDESourceControlWCCName</key>
+			<string>XMPPFramework</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkCoreDataTests/CapabilitiesHashingTest.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkCoreDataTests/CapabilitiesHashingTest.m
@@ -1,0 +1,143 @@
+//
+//  CapabilitiesHashingTest.m
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "NSData+XMPP.h"
+#import "NSXMLElement+XMPP.h"
+#import "XMPPCapabilitiesCoreDataStorage.h"
+
+@interface XMPPCapabilities (Private)
++ (NSString *)hashCapabilitiesFromQuery:(NSXMLElement *)query;
+@end
+
+@interface CapabilitiesHashingTest : XCTestCase
+@end
+
+@implementation CapabilitiesHashingTest
+
+- (void)test1
+{
+    // From XEP-0115, Section 5.2
+    
+    NSMutableString *s = [NSMutableString string];
+    [s appendString:@"<query xmlns='http://jabber.org/protocol/disco#info'>"];
+    [s appendString:@"  <identity category='client' name='Exodus 0.9.1' type='pc'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/caps'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/disco#info'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/disco#items'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/muc'/>"];
+    [s appendString:@"</query>"];
+    
+    NSXMLDocument *doc = [[NSXMLDocument alloc] initWithXMLString:s options:0 error:nil];
+    
+    NSXMLElement *query = [doc rootElement];
+    
+    NSString *expected = @"QgayPKawpkPSDYmwT/WM94uAlu0=";
+    
+    XCTAssertEqualObjects([XMPPCapabilities hashCapabilitiesFromQuery:query], expected);
+}
+
+- (void)test2
+{
+    // From XEP-0115, Section 5.3
+    
+    NSMutableString *s = [NSMutableString string];
+    [s appendString:@"<query xmlns='http://jabber.org/protocol/disco#info'>"];
+    [s appendString:@"  <identity xml:lang='en' category='client' name='Psi 0.11' type='pc'/>"];
+    [s appendString:@"  <identity xml:lang='el' category='client' name='Ψ 0.11' type='pc'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/caps'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/disco#info'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/disco#items'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/muc'/>"];
+    [s appendString:@"  <x xmlns='jabber:x:data' type='result'>"];
+    [s appendString:@"    <field var='FORM_TYPE' type='hidden'>"];
+    [s appendString:@"      <value>urn:xmpp:dataforms:softwareinfo</value>"];
+    [s appendString:@"    </field>"];
+    [s appendString:@"    <field var='ip_version'>"];
+    [s appendString:@"      <value>ipv4</value>"];
+    [s appendString:@"      <value>ipv6</value>"];
+    [s appendString:@"    </field>"];
+    [s appendString:@"    <field var='os'>"];
+    [s appendString:@"      <value>Mac</value>"];
+    [s appendString:@"    </field>"];
+    [s appendString:@"    <field var='os_version'>"];
+    [s appendString:@"      <value>10.5.1</value>"];
+    [s appendString:@"    </field>"];
+    [s appendString:@"    <field var='software'>"];
+    [s appendString:@"      <value>Psi</value>"];
+    [s appendString:@"    </field>"];
+    [s appendString:@"    <field var='software_version'>"];
+    [s appendString:@"      <value>0.11</value>"];
+    [s appendString:@"    </field>"];
+    [s appendString:@"  </x>"];
+    [s appendString:@"</query>"];
+    
+    NSXMLDocument *doc = [[NSXMLDocument alloc] initWithXMLString:s options:0 error:nil];
+    
+    NSXMLElement *query = [doc rootElement];
+    
+    NSString *expected = @"q07IKJEyjvHSyhy//CH0CxmKi8w=";
+    
+    XCTAssertEqualObjects([XMPPCapabilities hashCapabilitiesFromQuery:query], expected);
+}
+
+- (void)test3
+{
+    NSMutableString *s = [NSMutableString string];
+    [s appendString:@"<query node='http://pidgin.im/#WsE3KKs1gYLeYKAn5zQHkTkRnUA='"];
+    [s appendString:@"      xmlns='http://jabber.org/protocol/disco#info'>"];
+    [s appendString:@"  <identity category='client' name='Pidgin' type='pc'/>"];
+    [s appendString:@"  <feature var='jabber:iq:last'/>"];
+    [s appendString:@"  <feature var='jabber:iq:oob'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:time'/>"];
+    [s appendString:@"  <feature var='jabber:iq:version'/>"];
+    [s appendString:@"  <feature var='jabber:x:conference'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/bytestreams'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/caps'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/chatstates'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/disco#info'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/disco#items'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/muc'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/muc#user'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/si'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/si/profile/file-transfer'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/xhtml-im'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:ping'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:bob'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:jingle:1'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:jingle:transports:raw-udp:1'/>"];
+    [s appendString:@"  <feature var='http://www.google.com/xmpp/protocol/session'/>"];
+    [s appendString:@"  <feature var='http://www.google.com/xmpp/protocol/voice/v1'/>"];
+    [s appendString:@"  <feature var='http://www.google.com/xmpp/protocol/video/v1'/>"];
+    [s appendString:@"  <feature var='http://www.google.com/xmpp/protocol/camera/v1'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:jingle:apps:rtp:audio'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:jingle:apps:rtp:video'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:jingle:transports:ice-udp:1'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:avatar:metadata'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:avatar:data'/>"];
+    [s appendString:@"  <feature var='urn:xmpp:avatar:metadata+notify'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/mood'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/mood+notify'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/tune'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/tune+notify'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/nick'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/nick+notify'/>"];
+    [s appendString:@"  <feature var='http://jabber.org/protocol/ibb'/>"];
+    [s appendString:@"</query>"];
+    
+    NSXMLDocument *doc = [[NSXMLDocument alloc] initWithXMLString:s options:0 error:nil];
+    
+    NSXMLElement *query = [doc rootElement];
+    
+    NSString *expected = @"WsE3KKs1gYLeYKAn5zQHkTkRnUA=";
+    
+    XCTAssertEqualObjects([XMPPCapabilities hashCapabilitiesFromQuery:query], expected);
+}
+
+@end

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkCoreDataTests/Info.plist
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkCoreDataTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.paulmelnikow.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		90F596D50A8AB2CD874C400D /* libPods-XMPPFrameworkTestsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E12FE78966D1CF605B0A4F20 /* libPods-XMPPFrameworkTestsTests.a */; };
 		9EF4C5A71AE2C2C50019F001 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5A61AE2C2C50019F001 /* main.m */; };
 		9EF4C5AA1AE2C2C50019F001 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5A91AE2C2C50019F001 /* AppDelegate.m */; };
 		9EF4C5AD1AE2C2C50019F001 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5AC1AE2C2C50019F001 /* ViewController.m */; };
@@ -59,6 +60,7 @@
 		9EF4C7CC1AE2C43F0019F001 /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7CB1AE2C43F0019F001 /* libidn.a */; };
 		9EF4C7CE1AE2C4480019F001 /* libresolv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */; };
 		9EF4C7D31AE2C4CC0019F001 /* EncodeDecodeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */; };
+		9EF4C7D51AE2C6100019F001 /* MulticastDelegateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7D41AE2C6100019F001 /* MulticastDelegateTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +74,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		76C6AF82FDDA755AC643FD84 /* Pods-XMPPFrameworkTestsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTestsTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-XMPPFrameworkTestsTests/Pods-XMPPFrameworkTestsTests.release.xcconfig"; sourceTree = "<group>"; };
+		9508FAAF7823E030E62A713C /* Pods-XMPPFrameworkTestsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTestsTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-XMPPFrameworkTestsTests/Pods-XMPPFrameworkTestsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9EF4C5A11AE2C2C50019F001 /* XMPPFrameworkTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XMPPFrameworkTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9EF4C5A51AE2C2C50019F001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF4C5A61AE2C2C50019F001 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -180,6 +184,8 @@
 		9EF4C7CB1AE2C43F0019F001 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidn.a; path = ../../../Vendor/libidn/libidn.a; sourceTree = "<group>"; };
 		9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libresolv.dylib; path = usr/lib/libresolv.dylib; sourceTree = SDKROOT; };
 		9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncodeDecodeTest.m; sourceTree = "<group>"; };
+		9EF4C7D41AE2C6100019F001 /* MulticastDelegateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MulticastDelegateTest.m; sourceTree = "<group>"; };
+		E12FE78966D1CF605B0A4F20 /* libPods-XMPPFrameworkTestsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-XMPPFrameworkTestsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,12 +204,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90F596D50A8AB2CD874C400D /* libPods-XMPPFrameworkTestsTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2447A4F5551AFAD7B375B8C9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9508FAAF7823E030E62A713C /* Pods-XMPPFrameworkTestsTests.debug.xcconfig */,
+				76C6AF82FDDA755AC643FD84 /* Pods-XMPPFrameworkTestsTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		808D2D5B3A8FC3353BC1C1AD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E12FE78966D1CF605B0A4F20 /* libPods-XMPPFrameworkTestsTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9EF4C5981AE2C2C50019F001 = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +239,8 @@
 				9EF4C5A31AE2C2C50019F001 /* XMPPFrameworkTests */,
 				9EF4C5BD1AE2C2C50019F001 /* XMPPFrameworkTestsTests */,
 				9EF4C5A21AE2C2C50019F001 /* Products */,
+				2447A4F5551AFAD7B375B8C9 /* Pods */,
+				808D2D5B3A8FC3353BC1C1AD /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -255,6 +281,7 @@
 			isa = PBXGroup;
 			children = (
 				9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */,
+				9EF4C7D41AE2C6100019F001 /* MulticastDelegateTest.m */,
 				9EF4C5BE1AE2C2C50019F001 /* Supporting Files */,
 			);
 			path = XMPPFrameworkTestsTests;
@@ -551,9 +578,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9EF4C5C71AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTestsTests" */;
 			buildPhases = (
+				3A08A7ECFE07257C15BCB6B1 /* Check Pods Manifest.lock */,
 				9EF4C5B61AE2C2C50019F001 /* Sources */,
 				9EF4C5B71AE2C2C50019F001 /* Frameworks */,
 				9EF4C5B81AE2C2C50019F001 /* Resources */,
+				4AFD9EB379BB30AFE2AA08DE /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -623,6 +652,39 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		3A08A7ECFE07257C15BCB6B1 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		4AFD9EB379BB30AFE2AA08DE /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-XMPPFrameworkTestsTests/Pods-XMPPFrameworkTestsTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		9EF4C59D1AE2C2C50019F001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -679,6 +741,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9EF4C7D31AE2C4CC0019F001 /* EncodeDecodeTest.m in Sources */,
+				9EF4C7D51AE2C6100019F001 /* MulticastDelegateTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -830,6 +893,7 @@
 		};
 		9EF4C5C81AE2C2C50019F001 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9508FAAF7823E030E62A713C /* Pods-XMPPFrameworkTestsTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -849,6 +913,7 @@
 		};
 		9EF4C5C91AE2C2C50019F001 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 76C6AF82FDDA755AC643FD84 /* Pods-XMPPFrameworkTestsTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -881,6 +946,7 @@
 				9EF4C5C61AE2C2C50019F001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		9EF4C5C71AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTestsTests" */ = {
 			isa = XCConfigurationList;
@@ -889,6 +955,7 @@
 				9EF4C5C91AE2C2C50019F001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -8,6 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		90F596D50A8AB2CD874C400D /* libPods-XMPPFrameworkTestsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E12FE78966D1CF605B0A4F20 /* libPods-XMPPFrameworkTestsTests.a */; };
+		9E56CB3C1AE2F7E9008CE1D5 /* CapabilitiesHashingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB3B1AE2F7E9008CE1D5 /* CapabilitiesHashingTest.m */; };
+		9E56CB581AE2F823008CE1D5 /* XMPPCapabilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB4D1AE2F817008CE1D5 /* XMPPCapabilities.m */; };
+		9E56CB591AE2F82B008CE1D5 /* XMPPCapabilities.xcdatamodel in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB451AE2F817008CE1D5 /* XMPPCapabilities.xcdatamodel */; };
+		9E56CB5A1AE2F82B008CE1D5 /* XMPPCapabilitiesCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB471AE2F817008CE1D5 /* XMPPCapabilitiesCoreDataStorage.m */; };
+		9E56CB5B1AE2F82B008CE1D5 /* XMPPCapsCoreDataStorageObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB491AE2F817008CE1D5 /* XMPPCapsCoreDataStorageObject.m */; };
+		9E56CB5C1AE2F82B008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB4B1AE2F817008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.m */; };
+		9E56CB5D1AE2F831008CE1D5 /* XMPPCoreDataStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E56CB551AE2F81E008CE1D5 /* XMPPCoreDataStorage.m */; };
+		9E56CB5F1AE2F844008CE1D5 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E56CB5E1AE2F844008CE1D5 /* CoreData.framework */; };
 		9EF4C5A71AE2C2C50019F001 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5A61AE2C2C50019F001 /* main.m */; };
 		9EF4C5AA1AE2C2C50019F001 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5A91AE2C2C50019F001 /* AppDelegate.m */; };
 		9EF4C5AD1AE2C2C50019F001 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5AC1AE2C2C50019F001 /* ViewController.m */; };
@@ -64,6 +72,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		9E56CB3D1AE2F7E9008CE1D5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9EF4C5991AE2C2C50019F001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9EF4C5A01AE2C2C50019F001;
+			remoteInfo = XMPPFrameworkTests;
+		};
 		9EF4C5BB1AE2C2C50019F001 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9EF4C5991AE2C2C50019F001 /* Project object */;
@@ -76,6 +91,22 @@
 /* Begin PBXFileReference section */
 		76C6AF82FDDA755AC643FD84 /* Pods-XMPPFrameworkTestsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTestsTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-XMPPFrameworkTestsTests/Pods-XMPPFrameworkTestsTests.release.xcconfig"; sourceTree = "<group>"; };
 		9508FAAF7823E030E62A713C /* Pods-XMPPFrameworkTestsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTestsTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-XMPPFrameworkTestsTests/Pods-XMPPFrameworkTestsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9E56CB371AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkCoreDataTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E56CB3A1AE2F7E9008CE1D5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9E56CB3B1AE2F7E9008CE1D5 /* CapabilitiesHashingTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CapabilitiesHashingTest.m; sourceTree = "<group>"; };
+		9E56CB451AE2F817008CE1D5 /* XMPPCapabilities.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = XMPPCapabilities.xcdatamodel; sourceTree = "<group>"; };
+		9E56CB461AE2F817008CE1D5 /* XMPPCapabilitiesCoreDataStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCapabilitiesCoreDataStorage.h; sourceTree = "<group>"; };
+		9E56CB471AE2F817008CE1D5 /* XMPPCapabilitiesCoreDataStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPCapabilitiesCoreDataStorage.m; sourceTree = "<group>"; };
+		9E56CB481AE2F817008CE1D5 /* XMPPCapsCoreDataStorageObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCapsCoreDataStorageObject.h; sourceTree = "<group>"; };
+		9E56CB491AE2F817008CE1D5 /* XMPPCapsCoreDataStorageObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPCapsCoreDataStorageObject.m; sourceTree = "<group>"; };
+		9E56CB4A1AE2F817008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCapsResourceCoreDataStorageObject.h; sourceTree = "<group>"; };
+		9E56CB4B1AE2F817008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPCapsResourceCoreDataStorageObject.m; sourceTree = "<group>"; };
+		9E56CB4C1AE2F817008CE1D5 /* XMPPCapabilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCapabilities.h; sourceTree = "<group>"; };
+		9E56CB4D1AE2F817008CE1D5 /* XMPPCapabilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPCapabilities.m; sourceTree = "<group>"; };
+		9E56CB541AE2F81E008CE1D5 /* XMPPCoreDataStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCoreDataStorage.h; sourceTree = "<group>"; };
+		9E56CB551AE2F81E008CE1D5 /* XMPPCoreDataStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPCoreDataStorage.m; sourceTree = "<group>"; };
+		9E56CB561AE2F81E008CE1D5 /* XMPPCoreDataStorageProtected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCoreDataStorageProtected.h; sourceTree = "<group>"; };
+		9E56CB5E1AE2F844008CE1D5 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		9EF4C5A11AE2C2C50019F001 /* XMPPFrameworkTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XMPPFrameworkTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9EF4C5A51AE2C2C50019F001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9EF4C5A61AE2C2C50019F001 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -189,6 +220,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		9E56CB341AE2F7E9008CE1D5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9E56CB5F1AE2F844008CE1D5 /* CoreData.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9EF4C59E1AE2C2C50019F001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -223,9 +262,70 @@
 		808D2D5B3A8FC3353BC1C1AD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9E56CB5E1AE2F844008CE1D5 /* CoreData.framework */,
 				E12FE78966D1CF605B0A4F20 /* libPods-XMPPFrameworkTestsTests.a */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		9E56CB381AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests */ = {
+			isa = PBXGroup;
+			children = (
+				9E56CB3B1AE2F7E9008CE1D5 /* CapabilitiesHashingTest.m */,
+				9E56CB391AE2F7E9008CE1D5 /* Supporting Files */,
+			);
+			path = XMPPFrameworkCoreDataTests;
+			sourceTree = "<group>";
+		};
+		9E56CB391AE2F7E9008CE1D5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				9E56CB3A1AE2F7E9008CE1D5 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		9E56CB421AE2F808008CE1D5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9E56CB531AE2F81E008CE1D5 /* CoreDataStorage */,
+				9E56CB431AE2F817008CE1D5 /* XEP-0115 */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		9E56CB431AE2F817008CE1D5 /* XEP-0115 */ = {
+			isa = PBXGroup;
+			children = (
+				9E56CB441AE2F817008CE1D5 /* CoreDataStorage */,
+				9E56CB4C1AE2F817008CE1D5 /* XMPPCapabilities.h */,
+				9E56CB4D1AE2F817008CE1D5 /* XMPPCapabilities.m */,
+			);
+			path = "XEP-0115";
+			sourceTree = "<group>";
+		};
+		9E56CB441AE2F817008CE1D5 /* CoreDataStorage */ = {
+			isa = PBXGroup;
+			children = (
+				9E56CB451AE2F817008CE1D5 /* XMPPCapabilities.xcdatamodel */,
+				9E56CB461AE2F817008CE1D5 /* XMPPCapabilitiesCoreDataStorage.h */,
+				9E56CB471AE2F817008CE1D5 /* XMPPCapabilitiesCoreDataStorage.m */,
+				9E56CB481AE2F817008CE1D5 /* XMPPCapsCoreDataStorageObject.h */,
+				9E56CB491AE2F817008CE1D5 /* XMPPCapsCoreDataStorageObject.m */,
+				9E56CB4A1AE2F817008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.h */,
+				9E56CB4B1AE2F817008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.m */,
+			);
+			path = CoreDataStorage;
+			sourceTree = "<group>";
+		};
+		9E56CB531AE2F81E008CE1D5 /* CoreDataStorage */ = {
+			isa = PBXGroup;
+			children = (
+				9E56CB541AE2F81E008CE1D5 /* XMPPCoreDataStorage.h */,
+				9E56CB551AE2F81E008CE1D5 /* XMPPCoreDataStorage.m */,
+				9E56CB561AE2F81E008CE1D5 /* XMPPCoreDataStorageProtected.h */,
+			);
+			path = CoreDataStorage;
 			sourceTree = "<group>";
 		};
 		9EF4C5981AE2C2C50019F001 = {
@@ -238,6 +338,7 @@
 				9EF4C5CA1AE2C2D60019F001 /* XMPPFramework */,
 				9EF4C5A31AE2C2C50019F001 /* XMPPFrameworkTests */,
 				9EF4C5BD1AE2C2C50019F001 /* XMPPFrameworkTestsTests */,
+				9E56CB381AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests */,
 				9EF4C5A21AE2C2C50019F001 /* Products */,
 				2447A4F5551AFAD7B375B8C9 /* Pods */,
 				808D2D5B3A8FC3353BC1C1AD /* Frameworks */,
@@ -249,6 +350,7 @@
 			children = (
 				9EF4C5A11AE2C2C50019F001 /* XMPPFrameworkTests.app */,
 				9EF4C5BA1AE2C2C50019F001 /* XMPPFrameworkTestsTests.xctest */,
+				9E56CB371AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -298,6 +400,7 @@
 		9EF4C5CA1AE2C2D60019F001 /* XMPPFramework */ = {
 			isa = PBXGroup;
 			children = (
+				9E56CB421AE2F808008CE1D5 /* Extensions */,
 				9EF4C78D1AE2C3040019F001 /* Vendor */,
 				9EF4C5CB1AE2C2F30019F001 /* Utilities */,
 				9EF4C6D81AE2C2F30019F001 /* Core */,
@@ -557,6 +660,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		9E56CB361AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9E56CB411AE2F7E9008CE1D5 /* Build configuration list for PBXNativeTarget "XMPPFrameworkCoreDataTests" */;
+			buildPhases = (
+				9E56CB331AE2F7E9008CE1D5 /* Sources */,
+				9E56CB341AE2F7E9008CE1D5 /* Frameworks */,
+				9E56CB351AE2F7E9008CE1D5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9E56CB3E1AE2F7E9008CE1D5 /* PBXTargetDependency */,
+			);
+			name = XMPPFrameworkCoreDataTests;
+			productName = XMPPFrameworkCoreDataTests;
+			productReference = 9E56CB371AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9EF4C5C41AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTests" */;
@@ -603,6 +724,10 @@
 				LastUpgradeCheck = 0630;
 				ORGANIZATIONNAME = "Paul Melnikow";
 				TargetAttributes = {
+					9E56CB361AE2F7E9008CE1D5 = {
+						CreatedOnToolsVersion = 6.3;
+						TestTargetID = 9EF4C5A01AE2C2C50019F001;
+					};
 					9EF4C5A01AE2C2C50019F001 = {
 						CreatedOnToolsVersion = 6.3;
 					};
@@ -627,11 +752,19 @@
 			targets = (
 				9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */,
 				9EF4C5B91AE2C2C50019F001 /* XMPPFrameworkTestsTests */,
+				9E56CB361AE2F7E9008CE1D5 /* XMPPFrameworkCoreDataTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		9E56CB351AE2F7E9008CE1D5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9EF4C59F1AE2C2C50019F001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -686,6 +819,20 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		9E56CB331AE2F7E9008CE1D5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9E56CB591AE2F82B008CE1D5 /* XMPPCapabilities.xcdatamodel in Sources */,
+				9E56CB5A1AE2F82B008CE1D5 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
+				9E56CB581AE2F823008CE1D5 /* XMPPCapabilities.m in Sources */,
+				9E56CB5B1AE2F82B008CE1D5 /* XMPPCapsCoreDataStorageObject.m in Sources */,
+				9E56CB3C1AE2F7E9008CE1D5 /* CapabilitiesHashingTest.m in Sources */,
+				9E56CB5D1AE2F831008CE1D5 /* XMPPCoreDataStorage.m in Sources */,
+				9E56CB5C1AE2F82B008CE1D5 /* XMPPCapsResourceCoreDataStorageObject.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9EF4C59D1AE2C2C50019F001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -748,6 +895,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		9E56CB3E1AE2F7E9008CE1D5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */;
+			targetProxy = 9E56CB3D1AE2F7E9008CE1D5 /* PBXContainerItemProxy */;
+		};
 		9EF4C5BC1AE2C2C50019F001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */;
@@ -775,6 +927,40 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		9E56CB3F1AE2F7E9008CE1D5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = XMPPFrameworkCoreDataTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XMPPFrameworkTests.app/XMPPFrameworkTests";
+			};
+			name = Debug;
+		};
+		9E56CB401AE2F7E9008CE1D5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = XMPPFrameworkCoreDataTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XMPPFrameworkTests.app/XMPPFrameworkTests";
+			};
+			name = Release;
+		};
 		9EF4C5C21AE2C2C50019F001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -930,6 +1116,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		9E56CB411AE2F7E9008CE1D5 /* Build configuration list for PBXNativeTarget "XMPPFrameworkCoreDataTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9E56CB3F1AE2F7E9008CE1D5 /* Debug */,
+				9E56CB401AE2F7E9008CE1D5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		9EF4C59C1AE2C2C50019F001 /* Build configuration list for PBXProject "XMPPFrameworkTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -1,0 +1,896 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9EF4C5A71AE2C2C50019F001 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5A61AE2C2C50019F001 /* main.m */; };
+		9EF4C5AA1AE2C2C50019F001 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5A91AE2C2C50019F001 /* AppDelegate.m */; };
+		9EF4C5AD1AE2C2C50019F001 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5AC1AE2C2C50019F001 /* ViewController.m */; };
+		9EF4C5B01AE2C2C50019F001 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9EF4C5AE1AE2C2C50019F001 /* Main.storyboard */; };
+		9EF4C5B21AE2C2C50019F001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9EF4C5B11AE2C2C50019F001 /* Images.xcassets */; };
+		9EF4C5B51AE2C2C50019F001 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9EF4C5B31AE2C2C50019F001 /* LaunchScreen.xib */; };
+		9EF4C7101AE2C2F30019F001 /* DDList.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5CD1AE2C2F30019F001 /* DDList.m */; };
+		9EF4C7111AE2C2F30019F001 /* GCDMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5CF1AE2C2F30019F001 /* GCDMulticastDelegate.m */; };
+		9EF4C7121AE2C2F30019F001 /* RFImageToDataTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5D11AE2C2F30019F001 /* RFImageToDataTransformer.m */; };
+		9EF4C7131AE2C2F30019F001 /* XMPPIDTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5D31AE2C2F30019F001 /* XMPPIDTracker.m */; };
+		9EF4C7141AE2C2F30019F001 /* XMPPSRVResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5D51AE2C2F30019F001 /* XMPPSRVResolver.m */; };
+		9EF4C7151AE2C2F30019F001 /* XMPPStringPrep.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5D71AE2C2F30019F001 /* XMPPStringPrep.m */; };
+		9EF4C7161AE2C2F30019F001 /* XMPPTimer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C5D91AE2C2F30019F001 /* XMPPTimer.m */; };
+		9EF4C7791AE2C2F30019F001 /* XMPPConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6DB1AE2C2F30019F001 /* XMPPConstants.m */; };
+		9EF4C77A1AE2C2F30019F001 /* XMPPElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6DD1AE2C2F30019F001 /* XMPPElement.m */; };
+		9EF4C77B1AE2C2F30019F001 /* XMPPIQ.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6E01AE2C2F30019F001 /* XMPPIQ.m */; };
+		9EF4C77C1AE2C2F30019F001 /* XMPPJID.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6E21AE2C2F30019F001 /* XMPPJID.m */; };
+		9EF4C77D1AE2C2F30019F001 /* XMPPMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6E51AE2C2F30019F001 /* XMPPMessage.m */; };
+		9EF4C77E1AE2C2F30019F001 /* XMPPModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6E71AE2C2F30019F001 /* XMPPModule.m */; };
+		9EF4C77F1AE2C2F30019F001 /* XMPPParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6E91AE2C2F30019F001 /* XMPPParser.m */; };
+		9EF4C7801AE2C2F30019F001 /* XMPPPresence.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6EB1AE2C2F30019F001 /* XMPPPresence.m */; };
+		9EF4C7811AE2C2F30019F001 /* XMPPStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6ED1AE2C2F30019F001 /* XMPPStream.m */; };
+		9EF4C7821AE2C2F30019F001 /* NSData+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6F01AE2C2F30019F001 /* NSData+XMPP.m */; };
+		9EF4C7831AE2C2F30019F001 /* NSNumber+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6F21AE2C2F30019F001 /* NSNumber+XMPP.m */; };
+		9EF4C7841AE2C2F30019F001 /* NSXMLElement+XMPP.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6F41AE2C2F30019F001 /* NSXMLElement+XMPP.m */; };
+		9EF4C7851AE2C2F30019F001 /* XMPPAnonymousAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6F81AE2C2F30019F001 /* XMPPAnonymousAuthentication.m */; };
+		9EF4C7861AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6FB1AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.m */; };
+		9EF4C7871AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C6FE1AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.m */; };
+		9EF4C7881AE2C2F30019F001 /* XMPPDigestMD5Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7011AE2C2F30019F001 /* XMPPDigestMD5Authentication.m */; };
+		9EF4C7891AE2C2F30019F001 /* XMPPPlainAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7041AE2C2F30019F001 /* XMPPPlainAuthentication.m */; };
+		9EF4C78A1AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7071AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.m */; };
+		9EF4C78B1AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C70A1AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.m */; };
+		9EF4C78C1AE2C2F30019F001 /* XMPPXOAuth2Google.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C70D1AE2C2F30019F001 /* XMPPXOAuth2Google.m */; };
+		9EF4C7AC1AE2C3220019F001 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7951AE2C3220019F001 /* DDAbstractDatabaseLogger.m */; };
+		9EF4C7AD1AE2C3220019F001 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7971AE2C3220019F001 /* DDASLLogger.m */; };
+		9EF4C7AE1AE2C3220019F001 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7991AE2C3220019F001 /* DDFileLogger.m */; };
+		9EF4C7AF1AE2C3220019F001 /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C79C1AE2C3220019F001 /* DDLog.m */; };
+		9EF4C7B01AE2C3220019F001 /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C79E1AE2C3220019F001 /* DDTTYLogger.m */; };
+		9EF4C7B11AE2C3220019F001 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7A11AE2C3220019F001 /* DDContextFilterLogFormatter.m */; };
+		9EF4C7B21AE2C3220019F001 /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7A31AE2C3220019F001 /* DDDispatchQueueLogFormatter.m */; };
+		9EF4C7B31AE2C3220019F001 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7A51AE2C3220019F001 /* DDMultiFormatter.m */; };
+		9EF4C7B41AE2C3220019F001 /* README.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9EF4C7A61AE2C3220019F001 /* README.txt */; };
+		9EF4C7B51AE2C3220019F001 /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7A91AE2C3220019F001 /* GCDAsyncSocket.m */; };
+		9EF4C7C31AE2C39F0019F001 /* NSString+DDXML.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7B91AE2C39F0019F001 /* NSString+DDXML.m */; };
+		9EF4C7C41AE2C39F0019F001 /* DDXMLDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7BC1AE2C39F0019F001 /* DDXMLDocument.m */; };
+		9EF4C7C51AE2C39F0019F001 /* DDXMLElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7BE1AE2C39F0019F001 /* DDXMLElement.m */; };
+		9EF4C7C61AE2C39F0019F001 /* DDXMLNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7C01AE2C39F0019F001 /* DDXMLNode.m */; };
+		9EF4C7C81AE2C3B70019F001 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7C71AE2C3B70019F001 /* libxml2.dylib */; };
+		9EF4C7CA1AE2C4320019F001 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7C91AE2C4320019F001 /* Security.framework */; };
+		9EF4C7CC1AE2C43F0019F001 /* libidn.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7CB1AE2C43F0019F001 /* libidn.a */; };
+		9EF4C7CE1AE2C4480019F001 /* libresolv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */; };
+		9EF4C7D31AE2C4CC0019F001 /* EncodeDecodeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		9EF4C5BB1AE2C2C50019F001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9EF4C5991AE2C2C50019F001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9EF4C5A01AE2C2C50019F001;
+			remoteInfo = XMPPFrameworkTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		9EF4C5A11AE2C2C50019F001 /* XMPPFrameworkTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XMPPFrameworkTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9EF4C5A51AE2C2C50019F001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9EF4C5A61AE2C2C50019F001 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		9EF4C5A81AE2C2C50019F001 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		9EF4C5A91AE2C2C50019F001 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		9EF4C5AB1AE2C2C50019F001 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		9EF4C5AC1AE2C2C50019F001 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		9EF4C5AF1AE2C2C50019F001 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		9EF4C5B11AE2C2C50019F001 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		9EF4C5B41AE2C2C50019F001 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		9EF4C5BA1AE2C2C50019F001 /* XMPPFrameworkTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9EF4C5BF1AE2C2C50019F001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9EF4C5CC1AE2C2F30019F001 /* DDList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDList.h; sourceTree = "<group>"; };
+		9EF4C5CD1AE2C2F30019F001 /* DDList.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDList.m; sourceTree = "<group>"; };
+		9EF4C5CE1AE2C2F30019F001 /* GCDMulticastDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDMulticastDelegate.h; sourceTree = "<group>"; };
+		9EF4C5CF1AE2C2F30019F001 /* GCDMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDMulticastDelegate.m; sourceTree = "<group>"; };
+		9EF4C5D01AE2C2F30019F001 /* RFImageToDataTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RFImageToDataTransformer.h; sourceTree = "<group>"; };
+		9EF4C5D11AE2C2F30019F001 /* RFImageToDataTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFImageToDataTransformer.m; sourceTree = "<group>"; };
+		9EF4C5D21AE2C2F30019F001 /* XMPPIDTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIDTracker.h; sourceTree = "<group>"; };
+		9EF4C5D31AE2C2F30019F001 /* XMPPIDTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPIDTracker.m; sourceTree = "<group>"; };
+		9EF4C5D41AE2C2F30019F001 /* XMPPSRVResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSRVResolver.h; sourceTree = "<group>"; };
+		9EF4C5D51AE2C2F30019F001 /* XMPPSRVResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSRVResolver.m; sourceTree = "<group>"; };
+		9EF4C5D61AE2C2F30019F001 /* XMPPStringPrep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStringPrep.h; sourceTree = "<group>"; };
+		9EF4C5D71AE2C2F30019F001 /* XMPPStringPrep.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStringPrep.m; sourceTree = "<group>"; };
+		9EF4C5D81AE2C2F30019F001 /* XMPPTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPTimer.h; sourceTree = "<group>"; };
+		9EF4C5D91AE2C2F30019F001 /* XMPPTimer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPTimer.m; sourceTree = "<group>"; };
+		9EF4C6D91AE2C2F30019F001 /* XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPP.h; sourceTree = "<group>"; };
+		9EF4C6DA1AE2C2F30019F001 /* XMPPConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPConstants.h; sourceTree = "<group>"; };
+		9EF4C6DB1AE2C2F30019F001 /* XMPPConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPConstants.m; sourceTree = "<group>"; };
+		9EF4C6DC1AE2C2F30019F001 /* XMPPElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPElement.h; sourceTree = "<group>"; };
+		9EF4C6DD1AE2C2F30019F001 /* XMPPElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPElement.m; sourceTree = "<group>"; };
+		9EF4C6DE1AE2C2F30019F001 /* XMPPInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPInternal.h; sourceTree = "<group>"; };
+		9EF4C6DF1AE2C2F30019F001 /* XMPPIQ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPIQ.h; sourceTree = "<group>"; };
+		9EF4C6E01AE2C2F30019F001 /* XMPPIQ.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPIQ.m; sourceTree = "<group>"; };
+		9EF4C6E11AE2C2F30019F001 /* XMPPJID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPJID.h; sourceTree = "<group>"; };
+		9EF4C6E21AE2C2F30019F001 /* XMPPJID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPJID.m; sourceTree = "<group>"; };
+		9EF4C6E31AE2C2F30019F001 /* XMPPLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPLogging.h; sourceTree = "<group>"; };
+		9EF4C6E41AE2C2F30019F001 /* XMPPMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPMessage.h; sourceTree = "<group>"; };
+		9EF4C6E51AE2C2F30019F001 /* XMPPMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPMessage.m; sourceTree = "<group>"; };
+		9EF4C6E61AE2C2F30019F001 /* XMPPModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPModule.h; sourceTree = "<group>"; };
+		9EF4C6E71AE2C2F30019F001 /* XMPPModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPModule.m; sourceTree = "<group>"; };
+		9EF4C6E81AE2C2F30019F001 /* XMPPParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPParser.h; sourceTree = "<group>"; };
+		9EF4C6E91AE2C2F30019F001 /* XMPPParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPParser.m; sourceTree = "<group>"; };
+		9EF4C6EA1AE2C2F30019F001 /* XMPPPresence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPresence.h; sourceTree = "<group>"; };
+		9EF4C6EB1AE2C2F30019F001 /* XMPPPresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPresence.m; sourceTree = "<group>"; };
+		9EF4C6EC1AE2C2F30019F001 /* XMPPStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPStream.h; sourceTree = "<group>"; };
+		9EF4C6ED1AE2C2F30019F001 /* XMPPStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStream.m; sourceTree = "<group>"; };
+		9EF4C6EF1AE2C2F30019F001 /* NSData+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+XMPP.h"; sourceTree = "<group>"; };
+		9EF4C6F01AE2C2F30019F001 /* NSData+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+XMPP.m"; sourceTree = "<group>"; };
+		9EF4C6F11AE2C2F30019F001 /* NSNumber+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNumber+XMPP.h"; sourceTree = "<group>"; };
+		9EF4C6F21AE2C2F30019F001 /* NSNumber+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+XMPP.m"; sourceTree = "<group>"; };
+		9EF4C6F31AE2C2F30019F001 /* NSXMLElement+XMPP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSXMLElement+XMPP.h"; sourceTree = "<group>"; };
+		9EF4C6F41AE2C2F30019F001 /* NSXMLElement+XMPP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSXMLElement+XMPP.m"; sourceTree = "<group>"; };
+		9EF4C6F71AE2C2F30019F001 /* XMPPAnonymousAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPAnonymousAuthentication.h; sourceTree = "<group>"; };
+		9EF4C6F81AE2C2F30019F001 /* XMPPAnonymousAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPAnonymousAuthentication.m; sourceTree = "<group>"; };
+		9EF4C6FA1AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDeprecatedDigestAuthentication.h; sourceTree = "<group>"; };
+		9EF4C6FB1AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPDeprecatedDigestAuthentication.m; sourceTree = "<group>"; };
+		9EF4C6FD1AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDeprecatedPlainAuthentication.h; sourceTree = "<group>"; };
+		9EF4C6FE1AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPDeprecatedPlainAuthentication.m; sourceTree = "<group>"; };
+		9EF4C7001AE2C2F30019F001 /* XMPPDigestMD5Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPDigestMD5Authentication.h; sourceTree = "<group>"; };
+		9EF4C7011AE2C2F30019F001 /* XMPPDigestMD5Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPDigestMD5Authentication.m; sourceTree = "<group>"; };
+		9EF4C7031AE2C2F30019F001 /* XMPPPlainAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPPlainAuthentication.h; sourceTree = "<group>"; };
+		9EF4C7041AE2C2F30019F001 /* XMPPPlainAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPPlainAuthentication.m; sourceTree = "<group>"; };
+		9EF4C7061AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSCRAMSHA1Authentication.h; sourceTree = "<group>"; };
+		9EF4C7071AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPSCRAMSHA1Authentication.m; sourceTree = "<group>"; };
+		9EF4C7091AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPXFacebookPlatformAuthentication.h; sourceTree = "<group>"; };
+		9EF4C70A1AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPXFacebookPlatformAuthentication.m; sourceTree = "<group>"; };
+		9EF4C70C1AE2C2F30019F001 /* XMPPXOAuth2Google.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPXOAuth2Google.h; sourceTree = "<group>"; };
+		9EF4C70D1AE2C2F30019F001 /* XMPPXOAuth2Google.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPXOAuth2Google.m; sourceTree = "<group>"; };
+		9EF4C70E1AE2C2F30019F001 /* XMPPCustomBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPCustomBinding.h; sourceTree = "<group>"; };
+		9EF4C70F1AE2C2F30019F001 /* XMPPSASLAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPSASLAuthentication.h; sourceTree = "<group>"; };
+		9EF4C7901AE2C3220019F001 /* idn-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "idn-int.h"; sourceTree = "<group>"; };
+		9EF4C7921AE2C3220019F001 /* stringprep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stringprep.h; sourceTree = "<group>"; };
+		9EF4C7941AE2C3220019F001 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		9EF4C7951AE2C3220019F001 /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		9EF4C7961AE2C3220019F001 /* DDASLLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDASLLogger.h; sourceTree = "<group>"; };
+		9EF4C7971AE2C3220019F001 /* DDASLLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDASLLogger.m; sourceTree = "<group>"; };
+		9EF4C7981AE2C3220019F001 /* DDFileLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDFileLogger.h; sourceTree = "<group>"; };
+		9EF4C7991AE2C3220019F001 /* DDFileLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDFileLogger.m; sourceTree = "<group>"; };
+		9EF4C79A1AE2C3220019F001 /* DDLog+LOGV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "DDLog+LOGV.h"; sourceTree = "<group>"; };
+		9EF4C79B1AE2C3220019F001 /* DDLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDLog.h; sourceTree = "<group>"; };
+		9EF4C79C1AE2C3220019F001 /* DDLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLog.m; sourceTree = "<group>"; };
+		9EF4C79D1AE2C3220019F001 /* DDTTYLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDTTYLogger.h; sourceTree = "<group>"; };
+		9EF4C79E1AE2C3220019F001 /* DDTTYLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDTTYLogger.m; sourceTree = "<group>"; };
+		9EF4C7A01AE2C3220019F001 /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		9EF4C7A11AE2C3220019F001 /* DDContextFilterLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		9EF4C7A21AE2C3220019F001 /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		9EF4C7A31AE2C3220019F001 /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		9EF4C7A41AE2C3220019F001 /* DDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDMultiFormatter.h; sourceTree = "<group>"; };
+		9EF4C7A51AE2C3220019F001 /* DDMultiFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDMultiFormatter.m; sourceTree = "<group>"; };
+		9EF4C7A61AE2C3220019F001 /* README.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.txt; sourceTree = "<group>"; };
+		9EF4C7A81AE2C3220019F001 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncSocket.h; sourceTree = "<group>"; };
+		9EF4C7A91AE2C3220019F001 /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncSocket.m; sourceTree = "<group>"; };
+		9EF4C7B81AE2C39F0019F001 /* NSString+DDXML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+DDXML.h"; sourceTree = "<group>"; };
+		9EF4C7B91AE2C39F0019F001 /* NSString+DDXML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+DDXML.m"; sourceTree = "<group>"; };
+		9EF4C7BA1AE2C39F0019F001 /* DDXML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDXML.h; sourceTree = "<group>"; };
+		9EF4C7BB1AE2C39F0019F001 /* DDXMLDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDXMLDocument.h; sourceTree = "<group>"; };
+		9EF4C7BC1AE2C39F0019F001 /* DDXMLDocument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDXMLDocument.m; sourceTree = "<group>"; };
+		9EF4C7BD1AE2C39F0019F001 /* DDXMLElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDXMLElement.h; sourceTree = "<group>"; };
+		9EF4C7BE1AE2C39F0019F001 /* DDXMLElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDXMLElement.m; sourceTree = "<group>"; };
+		9EF4C7BF1AE2C39F0019F001 /* DDXMLNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDXMLNode.h; sourceTree = "<group>"; };
+		9EF4C7C01AE2C39F0019F001 /* DDXMLNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDXMLNode.m; sourceTree = "<group>"; };
+		9EF4C7C21AE2C39F0019F001 /* DDXMLPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDXMLPrivate.h; sourceTree = "<group>"; };
+		9EF4C7C71AE2C3B70019F001 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
+		9EF4C7C91AE2C4320019F001 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		9EF4C7CB1AE2C43F0019F001 /* libidn.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libidn.a; path = ../../../Vendor/libidn/libidn.a; sourceTree = "<group>"; };
+		9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libresolv.dylib; path = usr/lib/libresolv.dylib; sourceTree = SDKROOT; };
+		9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncodeDecodeTest.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9EF4C59E1AE2C2C50019F001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9EF4C7CE1AE2C4480019F001 /* libresolv.dylib in Frameworks */,
+				9EF4C7CC1AE2C43F0019F001 /* libidn.a in Frameworks */,
+				9EF4C7CA1AE2C4320019F001 /* Security.framework in Frameworks */,
+				9EF4C7C81AE2C3B70019F001 /* libxml2.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EF4C5B71AE2C2C50019F001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9EF4C5981AE2C2C50019F001 = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */,
+				9EF4C7CB1AE2C43F0019F001 /* libidn.a */,
+				9EF4C7C91AE2C4320019F001 /* Security.framework */,
+				9EF4C7C71AE2C3B70019F001 /* libxml2.dylib */,
+				9EF4C5CA1AE2C2D60019F001 /* XMPPFramework */,
+				9EF4C5A31AE2C2C50019F001 /* XMPPFrameworkTests */,
+				9EF4C5BD1AE2C2C50019F001 /* XMPPFrameworkTestsTests */,
+				9EF4C5A21AE2C2C50019F001 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9EF4C5A21AE2C2C50019F001 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5A11AE2C2C50019F001 /* XMPPFrameworkTests.app */,
+				9EF4C5BA1AE2C2C50019F001 /* XMPPFrameworkTestsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9EF4C5A31AE2C2C50019F001 /* XMPPFrameworkTests */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5A81AE2C2C50019F001 /* AppDelegate.h */,
+				9EF4C5A91AE2C2C50019F001 /* AppDelegate.m */,
+				9EF4C5AB1AE2C2C50019F001 /* ViewController.h */,
+				9EF4C5AC1AE2C2C50019F001 /* ViewController.m */,
+				9EF4C5AE1AE2C2C50019F001 /* Main.storyboard */,
+				9EF4C5B11AE2C2C50019F001 /* Images.xcassets */,
+				9EF4C5B31AE2C2C50019F001 /* LaunchScreen.xib */,
+				9EF4C5A41AE2C2C50019F001 /* Supporting Files */,
+			);
+			path = XMPPFrameworkTests;
+			sourceTree = "<group>";
+		};
+		9EF4C5A41AE2C2C50019F001 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5A51AE2C2C50019F001 /* Info.plist */,
+				9EF4C5A61AE2C2C50019F001 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		9EF4C5BD1AE2C2C50019F001 /* XMPPFrameworkTestsTests */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */,
+				9EF4C5BE1AE2C2C50019F001 /* Supporting Files */,
+			);
+			path = XMPPFrameworkTestsTests;
+			sourceTree = "<group>";
+		};
+		9EF4C5BE1AE2C2C50019F001 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5BF1AE2C2C50019F001 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		9EF4C5CA1AE2C2D60019F001 /* XMPPFramework */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C78D1AE2C3040019F001 /* Vendor */,
+				9EF4C5CB1AE2C2F30019F001 /* Utilities */,
+				9EF4C6D81AE2C2F30019F001 /* Core */,
+				9EF4C6EE1AE2C2F30019F001 /* Categories */,
+				9EF4C6F51AE2C2F30019F001 /* Authentication */,
+			);
+			name = XMPPFramework;
+			path = ../../..;
+			sourceTree = "<group>";
+		};
+		9EF4C5CB1AE2C2F30019F001 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C5CC1AE2C2F30019F001 /* DDList.h */,
+				9EF4C5CD1AE2C2F30019F001 /* DDList.m */,
+				9EF4C5CE1AE2C2F30019F001 /* GCDMulticastDelegate.h */,
+				9EF4C5CF1AE2C2F30019F001 /* GCDMulticastDelegate.m */,
+				9EF4C5D01AE2C2F30019F001 /* RFImageToDataTransformer.h */,
+				9EF4C5D11AE2C2F30019F001 /* RFImageToDataTransformer.m */,
+				9EF4C5D21AE2C2F30019F001 /* XMPPIDTracker.h */,
+				9EF4C5D31AE2C2F30019F001 /* XMPPIDTracker.m */,
+				9EF4C5D41AE2C2F30019F001 /* XMPPSRVResolver.h */,
+				9EF4C5D51AE2C2F30019F001 /* XMPPSRVResolver.m */,
+				9EF4C5D61AE2C2F30019F001 /* XMPPStringPrep.h */,
+				9EF4C5D71AE2C2F30019F001 /* XMPPStringPrep.m */,
+				9EF4C5D81AE2C2F30019F001 /* XMPPTimer.h */,
+				9EF4C5D91AE2C2F30019F001 /* XMPPTimer.m */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		9EF4C6D81AE2C2F30019F001 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C6D91AE2C2F30019F001 /* XMPP.h */,
+				9EF4C6DA1AE2C2F30019F001 /* XMPPConstants.h */,
+				9EF4C6DB1AE2C2F30019F001 /* XMPPConstants.m */,
+				9EF4C6DC1AE2C2F30019F001 /* XMPPElement.h */,
+				9EF4C6DD1AE2C2F30019F001 /* XMPPElement.m */,
+				9EF4C6DE1AE2C2F30019F001 /* XMPPInternal.h */,
+				9EF4C6DF1AE2C2F30019F001 /* XMPPIQ.h */,
+				9EF4C6E01AE2C2F30019F001 /* XMPPIQ.m */,
+				9EF4C6E11AE2C2F30019F001 /* XMPPJID.h */,
+				9EF4C6E21AE2C2F30019F001 /* XMPPJID.m */,
+				9EF4C6E31AE2C2F30019F001 /* XMPPLogging.h */,
+				9EF4C6E41AE2C2F30019F001 /* XMPPMessage.h */,
+				9EF4C6E51AE2C2F30019F001 /* XMPPMessage.m */,
+				9EF4C6E61AE2C2F30019F001 /* XMPPModule.h */,
+				9EF4C6E71AE2C2F30019F001 /* XMPPModule.m */,
+				9EF4C6E81AE2C2F30019F001 /* XMPPParser.h */,
+				9EF4C6E91AE2C2F30019F001 /* XMPPParser.m */,
+				9EF4C6EA1AE2C2F30019F001 /* XMPPPresence.h */,
+				9EF4C6EB1AE2C2F30019F001 /* XMPPPresence.m */,
+				9EF4C6EC1AE2C2F30019F001 /* XMPPStream.h */,
+				9EF4C6ED1AE2C2F30019F001 /* XMPPStream.m */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		9EF4C6EE1AE2C2F30019F001 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C6EF1AE2C2F30019F001 /* NSData+XMPP.h */,
+				9EF4C6F01AE2C2F30019F001 /* NSData+XMPP.m */,
+				9EF4C6F11AE2C2F30019F001 /* NSNumber+XMPP.h */,
+				9EF4C6F21AE2C2F30019F001 /* NSNumber+XMPP.m */,
+				9EF4C6F31AE2C2F30019F001 /* NSXMLElement+XMPP.h */,
+				9EF4C6F41AE2C2F30019F001 /* NSXMLElement+XMPP.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		9EF4C6F51AE2C2F30019F001 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C6F61AE2C2F30019F001 /* Anonymous */,
+				9EF4C6F91AE2C2F30019F001 /* Deprecated-Digest */,
+				9EF4C6FC1AE2C2F30019F001 /* Deprecated-Plain */,
+				9EF4C6FF1AE2C2F30019F001 /* Digest-MD5 */,
+				9EF4C7021AE2C2F30019F001 /* Plain */,
+				9EF4C7051AE2C2F30019F001 /* SCRAM-SHA-1 */,
+				9EF4C7081AE2C2F30019F001 /* X-Facebook-Platform */,
+				9EF4C70B1AE2C2F30019F001 /* X-OAuth2-Google */,
+				9EF4C70E1AE2C2F30019F001 /* XMPPCustomBinding.h */,
+				9EF4C70F1AE2C2F30019F001 /* XMPPSASLAuthentication.h */,
+			);
+			path = Authentication;
+			sourceTree = "<group>";
+		};
+		9EF4C6F61AE2C2F30019F001 /* Anonymous */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C6F71AE2C2F30019F001 /* XMPPAnonymousAuthentication.h */,
+				9EF4C6F81AE2C2F30019F001 /* XMPPAnonymousAuthentication.m */,
+			);
+			path = Anonymous;
+			sourceTree = "<group>";
+		};
+		9EF4C6F91AE2C2F30019F001 /* Deprecated-Digest */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C6FA1AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.h */,
+				9EF4C6FB1AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.m */,
+			);
+			path = "Deprecated-Digest";
+			sourceTree = "<group>";
+		};
+		9EF4C6FC1AE2C2F30019F001 /* Deprecated-Plain */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C6FD1AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.h */,
+				9EF4C6FE1AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.m */,
+			);
+			path = "Deprecated-Plain";
+			sourceTree = "<group>";
+		};
+		9EF4C6FF1AE2C2F30019F001 /* Digest-MD5 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7001AE2C2F30019F001 /* XMPPDigestMD5Authentication.h */,
+				9EF4C7011AE2C2F30019F001 /* XMPPDigestMD5Authentication.m */,
+			);
+			path = "Digest-MD5";
+			sourceTree = "<group>";
+		};
+		9EF4C7021AE2C2F30019F001 /* Plain */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7031AE2C2F30019F001 /* XMPPPlainAuthentication.h */,
+				9EF4C7041AE2C2F30019F001 /* XMPPPlainAuthentication.m */,
+			);
+			path = Plain;
+			sourceTree = "<group>";
+		};
+		9EF4C7051AE2C2F30019F001 /* SCRAM-SHA-1 */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7061AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.h */,
+				9EF4C7071AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.m */,
+			);
+			path = "SCRAM-SHA-1";
+			sourceTree = "<group>";
+		};
+		9EF4C7081AE2C2F30019F001 /* X-Facebook-Platform */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7091AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.h */,
+				9EF4C70A1AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.m */,
+			);
+			path = "X-Facebook-Platform";
+			sourceTree = "<group>";
+		};
+		9EF4C70B1AE2C2F30019F001 /* X-OAuth2-Google */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C70C1AE2C2F30019F001 /* XMPPXOAuth2Google.h */,
+				9EF4C70D1AE2C2F30019F001 /* XMPPXOAuth2Google.m */,
+			);
+			path = "X-OAuth2-Google";
+			sourceTree = "<group>";
+		};
+		9EF4C78D1AE2C3040019F001 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7B61AE2C39F0019F001 /* KissXML */,
+				9EF4C78E1AE2C3220019F001 /* libidn */,
+				9EF4C7931AE2C3220019F001 /* CocoaLumberjack */,
+				9EF4C7A71AE2C3220019F001 /* CocoaAsyncSocket */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		9EF4C78E1AE2C3220019F001 /* libidn */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7901AE2C3220019F001 /* idn-int.h */,
+				9EF4C7921AE2C3220019F001 /* stringprep.h */,
+			);
+			path = libidn;
+			sourceTree = "<group>";
+		};
+		9EF4C7931AE2C3220019F001 /* CocoaLumberjack */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7941AE2C3220019F001 /* DDAbstractDatabaseLogger.h */,
+				9EF4C7951AE2C3220019F001 /* DDAbstractDatabaseLogger.m */,
+				9EF4C7961AE2C3220019F001 /* DDASLLogger.h */,
+				9EF4C7971AE2C3220019F001 /* DDASLLogger.m */,
+				9EF4C7981AE2C3220019F001 /* DDFileLogger.h */,
+				9EF4C7991AE2C3220019F001 /* DDFileLogger.m */,
+				9EF4C79A1AE2C3220019F001 /* DDLog+LOGV.h */,
+				9EF4C79B1AE2C3220019F001 /* DDLog.h */,
+				9EF4C79C1AE2C3220019F001 /* DDLog.m */,
+				9EF4C79D1AE2C3220019F001 /* DDTTYLogger.h */,
+				9EF4C79E1AE2C3220019F001 /* DDTTYLogger.m */,
+				9EF4C79F1AE2C3220019F001 /* Extensions */,
+			);
+			path = CocoaLumberjack;
+			sourceTree = "<group>";
+		};
+		9EF4C79F1AE2C3220019F001 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7A01AE2C3220019F001 /* DDContextFilterLogFormatter.h */,
+				9EF4C7A11AE2C3220019F001 /* DDContextFilterLogFormatter.m */,
+				9EF4C7A21AE2C3220019F001 /* DDDispatchQueueLogFormatter.h */,
+				9EF4C7A31AE2C3220019F001 /* DDDispatchQueueLogFormatter.m */,
+				9EF4C7A41AE2C3220019F001 /* DDMultiFormatter.h */,
+				9EF4C7A51AE2C3220019F001 /* DDMultiFormatter.m */,
+				9EF4C7A61AE2C3220019F001 /* README.txt */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		9EF4C7A71AE2C3220019F001 /* CocoaAsyncSocket */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7A81AE2C3220019F001 /* GCDAsyncSocket.h */,
+				9EF4C7A91AE2C3220019F001 /* GCDAsyncSocket.m */,
+			);
+			path = CocoaAsyncSocket;
+			sourceTree = "<group>";
+		};
+		9EF4C7B61AE2C39F0019F001 /* KissXML */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7B71AE2C39F0019F001 /* Categories */,
+				9EF4C7BA1AE2C39F0019F001 /* DDXML.h */,
+				9EF4C7BB1AE2C39F0019F001 /* DDXMLDocument.h */,
+				9EF4C7BC1AE2C39F0019F001 /* DDXMLDocument.m */,
+				9EF4C7BD1AE2C39F0019F001 /* DDXMLElement.h */,
+				9EF4C7BE1AE2C39F0019F001 /* DDXMLElement.m */,
+				9EF4C7BF1AE2C39F0019F001 /* DDXMLNode.h */,
+				9EF4C7C01AE2C39F0019F001 /* DDXMLNode.m */,
+				9EF4C7C11AE2C39F0019F001 /* Private */,
+			);
+			path = KissXML;
+			sourceTree = "<group>";
+		};
+		9EF4C7B71AE2C39F0019F001 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7B81AE2C39F0019F001 /* NSString+DDXML.h */,
+				9EF4C7B91AE2C39F0019F001 /* NSString+DDXML.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		9EF4C7C11AE2C39F0019F001 /* Private */ = {
+			isa = PBXGroup;
+			children = (
+				9EF4C7C21AE2C39F0019F001 /* DDXMLPrivate.h */,
+			);
+			path = Private;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9EF4C5C41AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTests" */;
+			buildPhases = (
+				9EF4C59D1AE2C2C50019F001 /* Sources */,
+				9EF4C59E1AE2C2C50019F001 /* Frameworks */,
+				9EF4C59F1AE2C2C50019F001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XMPPFrameworkTests;
+			productName = XMPPFrameworkTests;
+			productReference = 9EF4C5A11AE2C2C50019F001 /* XMPPFrameworkTests.app */;
+			productType = "com.apple.product-type.application";
+		};
+		9EF4C5B91AE2C2C50019F001 /* XMPPFrameworkTestsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9EF4C5C71AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTestsTests" */;
+			buildPhases = (
+				9EF4C5B61AE2C2C50019F001 /* Sources */,
+				9EF4C5B71AE2C2C50019F001 /* Frameworks */,
+				9EF4C5B81AE2C2C50019F001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9EF4C5BC1AE2C2C50019F001 /* PBXTargetDependency */,
+			);
+			name = XMPPFrameworkTestsTests;
+			productName = XMPPFrameworkTestsTests;
+			productReference = 9EF4C5BA1AE2C2C50019F001 /* XMPPFrameworkTestsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9EF4C5991AE2C2C50019F001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = "Paul Melnikow";
+				TargetAttributes = {
+					9EF4C5A01AE2C2C50019F001 = {
+						CreatedOnToolsVersion = 6.3;
+					};
+					9EF4C5B91AE2C2C50019F001 = {
+						CreatedOnToolsVersion = 6.3;
+						TestTargetID = 9EF4C5A01AE2C2C50019F001;
+					};
+				};
+			};
+			buildConfigurationList = 9EF4C59C1AE2C2C50019F001 /* Build configuration list for PBXProject "XMPPFrameworkTests" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9EF4C5981AE2C2C50019F001;
+			productRefGroup = 9EF4C5A21AE2C2C50019F001 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */,
+				9EF4C5B91AE2C2C50019F001 /* XMPPFrameworkTestsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9EF4C59F1AE2C2C50019F001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9EF4C5B01AE2C2C50019F001 /* Main.storyboard in Resources */,
+				9EF4C5B51AE2C2C50019F001 /* LaunchScreen.xib in Resources */,
+				9EF4C5B21AE2C2C50019F001 /* Images.xcassets in Resources */,
+				9EF4C7B41AE2C3220019F001 /* README.txt in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EF4C5B81AE2C2C50019F001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9EF4C59D1AE2C2C50019F001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9EF4C7821AE2C2F30019F001 /* NSData+XMPP.m in Sources */,
+				9EF4C7851AE2C2F30019F001 /* XMPPAnonymousAuthentication.m in Sources */,
+				9EF4C77D1AE2C2F30019F001 /* XMPPMessage.m in Sources */,
+				9EF4C78B1AE2C2F30019F001 /* XMPPXFacebookPlatformAuthentication.m in Sources */,
+				9EF4C7161AE2C2F30019F001 /* XMPPTimer.m in Sources */,
+				9EF4C7121AE2C2F30019F001 /* RFImageToDataTransformer.m in Sources */,
+				9EF4C7151AE2C2F30019F001 /* XMPPStringPrep.m in Sources */,
+				9EF4C7791AE2C2F30019F001 /* XMPPConstants.m in Sources */,
+				9EF4C7C51AE2C39F0019F001 /* DDXMLElement.m in Sources */,
+				9EF4C7C61AE2C39F0019F001 /* DDXMLNode.m in Sources */,
+				9EF4C7B21AE2C3220019F001 /* DDDispatchQueueLogFormatter.m in Sources */,
+				9EF4C77E1AE2C2F30019F001 /* XMPPModule.m in Sources */,
+				9EF4C5AD1AE2C2C50019F001 /* ViewController.m in Sources */,
+				9EF4C7811AE2C2F30019F001 /* XMPPStream.m in Sources */,
+				9EF4C78C1AE2C2F30019F001 /* XMPPXOAuth2Google.m in Sources */,
+				9EF4C7AF1AE2C3220019F001 /* DDLog.m in Sources */,
+				9EF4C7841AE2C2F30019F001 /* NSXMLElement+XMPP.m in Sources */,
+				9EF4C7131AE2C2F30019F001 /* XMPPIDTracker.m in Sources */,
+				9EF4C77C1AE2C2F30019F001 /* XMPPJID.m in Sources */,
+				9EF4C5AA1AE2C2C50019F001 /* AppDelegate.m in Sources */,
+				9EF4C5A71AE2C2C50019F001 /* main.m in Sources */,
+				9EF4C7AC1AE2C3220019F001 /* DDAbstractDatabaseLogger.m in Sources */,
+				9EF4C7101AE2C2F30019F001 /* DDList.m in Sources */,
+				9EF4C7881AE2C2F30019F001 /* XMPPDigestMD5Authentication.m in Sources */,
+				9EF4C7C41AE2C39F0019F001 /* DDXMLDocument.m in Sources */,
+				9EF4C7891AE2C2F30019F001 /* XMPPPlainAuthentication.m in Sources */,
+				9EF4C77B1AE2C2F30019F001 /* XMPPIQ.m in Sources */,
+				9EF4C7141AE2C2F30019F001 /* XMPPSRVResolver.m in Sources */,
+				9EF4C77F1AE2C2F30019F001 /* XMPPParser.m in Sources */,
+				9EF4C7B01AE2C3220019F001 /* DDTTYLogger.m in Sources */,
+				9EF4C7111AE2C2F30019F001 /* GCDMulticastDelegate.m in Sources */,
+				9EF4C7861AE2C2F30019F001 /* XMPPDeprecatedDigestAuthentication.m in Sources */,
+				9EF4C7AD1AE2C3220019F001 /* DDASLLogger.m in Sources */,
+				9EF4C7831AE2C2F30019F001 /* NSNumber+XMPP.m in Sources */,
+				9EF4C7871AE2C2F30019F001 /* XMPPDeprecatedPlainAuthentication.m in Sources */,
+				9EF4C77A1AE2C2F30019F001 /* XMPPElement.m in Sources */,
+				9EF4C7B11AE2C3220019F001 /* DDContextFilterLogFormatter.m in Sources */,
+				9EF4C7B51AE2C3220019F001 /* GCDAsyncSocket.m in Sources */,
+				9EF4C7B31AE2C3220019F001 /* DDMultiFormatter.m in Sources */,
+				9EF4C78A1AE2C2F30019F001 /* XMPPSCRAMSHA1Authentication.m in Sources */,
+				9EF4C7801AE2C2F30019F001 /* XMPPPresence.m in Sources */,
+				9EF4C7AE1AE2C3220019F001 /* DDFileLogger.m in Sources */,
+				9EF4C7C31AE2C39F0019F001 /* NSString+DDXML.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9EF4C5B61AE2C2C50019F001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9EF4C7D31AE2C4CC0019F001 /* EncodeDecodeTest.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9EF4C5BC1AE2C2C50019F001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9EF4C5A01AE2C2C50019F001 /* XMPPFrameworkTests */;
+			targetProxy = 9EF4C5BB1AE2C2C50019F001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		9EF4C5AE1AE2C2C50019F001 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				9EF4C5AF1AE2C2C50019F001 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		9EF4C5B31AE2C2C50019F001 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				9EF4C5B41AE2C2C50019F001 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		9EF4C5C21AE2C2C50019F001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"/usr/include/libxml2/**",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		9EF4C5C31AE2C2C50019F001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"/usr/include/libxml2/**",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9EF4C5C51AE2C2C50019F001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = XMPPFrameworkTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/Users/pnm/code/XMPPFramework/Vendor/libidn,
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		9EF4C5C61AE2C2C50019F001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = XMPPFrameworkTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					/Users/pnm/code/XMPPFramework/Vendor/libidn,
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		9EF4C5C81AE2C2C50019F001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = XMPPFrameworkTestsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XMPPFrameworkTests.app/XMPPFrameworkTests";
+			};
+			name = Debug;
+		};
+		9EF4C5C91AE2C2C50019F001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = XMPPFrameworkTestsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/XMPPFrameworkTests.app/XMPPFrameworkTests";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9EF4C59C1AE2C2C50019F001 /* Build configuration list for PBXProject "XMPPFrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9EF4C5C21AE2C2C50019F001 /* Debug */,
+				9EF4C5C31AE2C2C50019F001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9EF4C5C41AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9EF4C5C51AE2C2C50019F001 /* Debug */,
+				9EF4C5C61AE2C2C50019F001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		9EF4C5C71AE2C2C50019F001 /* Build configuration list for PBXNativeTarget "XMPPFrameworkTestsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9EF4C5C81AE2C2C50019F001 /* Debug */,
+				9EF4C5C91AE2C2C50019F001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9EF4C5991AE2C2C50019F001 /* Project object */;
+}

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/AppDelegate.h
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/AppDelegate.h
@@ -1,0 +1,17 @@
+//
+//  AppDelegate.h
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/AppDelegate.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/AppDelegate.m
@@ -1,0 +1,45 @@
+//
+//  AppDelegate.m
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Override point for customization after application launch.
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Base.lproj/LaunchScreen.xib
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Paul Melnikow. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="XMPPFrameworkTests" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Base.lproj/Main.storyboard
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="ufC-wZ-h7g">
+            <objects>
+                <viewController id="vXZ-lx-hvc" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="jyV-Pf-zRb"/>
+                        <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Info.plist
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.paulmelnikow.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/ViewController.h
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/ViewController.h
@@ -1,0 +1,15 @@
+//
+//  ViewController.h
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/ViewController.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/ViewController.m
@@ -1,0 +1,27 @@
+//
+//  ViewController.m
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view, typically from a nib.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/main.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/EncodeDecodeTest.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/EncodeDecodeTest.m
@@ -1,0 +1,101 @@
+//
+//  EncodeDecodeTest.m
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "XMPPJID.h"
+#import "XMPPElement.h"
+#import "XMPPIQ.h"
+#import "XMPPMessage.h"
+#import "XMPPPresence.h"
+
+@interface EncodeDecodeTest : XCTestCase
+
+@end
+
+@implementation EncodeDecodeTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testCopy
+{
+    XMPPJID *jid1 = [XMPPJID jidWithString:@"user@domain.com/resource"];
+    XMPPJID *jid2 = [jid1 copy];
+    
+    XCTAssert([jid1 isKindOfClass:[XMPPJID class]], @"A1");
+    XCTAssert([jid2 isKindOfClass:[XMPPJID class]], @"A2");
+    
+    XMPPIQ *iq1 = [XMPPIQ iqWithType:@"get" to:jid1 elementID:@"abc123"];
+    XMPPIQ *iq2 = [iq1 copy];
+    
+    XCTAssert([iq1 isKindOfClass:[XMPPIQ class]], @"B1");
+    XCTAssert([iq2 isKindOfClass:[XMPPIQ class]], @"B2");
+    
+    XMPPMessage *message1 = [XMPPMessage messageWithType:@"chat" to:jid1];
+    XMPPMessage *message2 = [message1 copy];
+    
+    XCTAssert([message1 isKindOfClass:[XMPPMessage class]], @"C1");
+    XCTAssert([message2 isKindOfClass:[XMPPMessage class]], @"C2");
+    
+    XMPPPresence *presence1 = [XMPPPresence presenceWithType:@"subscribe" to:jid1];
+    XMPPPresence *presence2 = [presence1 copy];
+    
+    XCTAssert([presence1 isKindOfClass:[XMPPPresence class]], @"D1");
+    XCTAssert([presence2 isKindOfClass:[XMPPPresence class]], @"D2");
+}
+
+- (void)testArchive
+{
+    NSMutableDictionary *dict1 = [NSMutableDictionary dictionaryWithCapacity:4];
+    
+    XMPPJID *jid1 = [XMPPJID jidWithString:@"user@domain.com/resource"];
+    [dict1 setObject:jid1 forKey:@"jid"];
+    
+    XMPPIQ *iq1 = [XMPPIQ iqWithType:@"get" to:jid1 elementID:@"abc123"];
+    [dict1 setObject:iq1 forKey:@"iq"];
+    
+    XMPPMessage *message1 = [XMPPMessage messageWithType:@"chat" to:jid1];
+    [dict1 setObject:message1 forKey:@"message"];
+    
+    XMPPPresence *presence1 = [XMPPPresence presenceWithType:@"subscribe" to:jid1];
+    [dict1 setObject:presence1 forKey:@"presence"];
+    
+    NSData *archive = [NSKeyedArchiver archivedDataWithRootObject:dict1];
+    
+    NSDictionary *dict2 = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+    
+    XMPPJID *jid2 = [dict2 objectForKey:@"jid"];
+    
+    XCTAssert([jid1 isKindOfClass:[XMPPJID class]], @"A1");
+    XCTAssert([jid2 isKindOfClass:[XMPPJID class]], @"A2");
+    
+    XMPPIQ *iq2 = [dict2 objectForKey:@"iq"];
+    
+    XCTAssert([iq1 isKindOfClass:[XMPPIQ class]], @"B1");
+    XCTAssert([iq2 isKindOfClass:[XMPPIQ class]], @"B2");
+    
+    XMPPMessage *message2 = [dict2 objectForKey:@"message"];
+    
+    XCTAssert([message1 isKindOfClass:[XMPPMessage class]], @"C1");
+    XCTAssert([message2 isKindOfClass:[XMPPMessage class]], @"C2");
+    
+    XMPPPresence *presence2 = [dict2 objectForKey:@"presence"];
+    
+    XCTAssert([presence1 isKindOfClass:[XMPPPresence class]], @"D1");
+    XCTAssert([presence2 isKindOfClass:[XMPPPresence class]], @"D2");
+}
+
+@end

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/Info.plist
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.paulmelnikow.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/MulticastDelegateTest.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/MulticastDelegateTest.m
@@ -1,0 +1,209 @@
+//
+//  MulticastDelegateTest.m
+//  XMPPFrameworkTests
+//
+//  Created by Paul Melnikow on 4/18/15.
+//  Copyright (c) 2015 Paul Melnikow. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "GCDMulticastDelegate.h"
+#import "OCMock/OCMock.h"
+
+@protocol MyProtocol
+@optional
+- (void)didSomething;
+- (void)didSomethingElse:(BOOL)flag;
+- (void)foundString:(NSString *)str;
+- (void)foundString:(NSString *)str andNumber:(NSNumber *)num;
+@end
+
+
+@interface MulticastDelegateTestBase : XCTestCase
+
+@property (strong) GCDMulticastDelegate<MyProtocol> * multicastDelegate;
+
+@property (strong) id del1;
+@property (strong) id del2;
+@property (strong) id del3;
+
+#if !OS_OBJECT_USE_OBJC
+@property (assign) dispatch_queue_t queue1;
+@property (assign) dispatch_queue_t queue2;
+@property (assign) dispatch_queue_t queue3;
+#else
+@property (strong) dispatch_queue_t queue1;
+@property (strong) dispatch_queue_t queue2;
+@property (strong) dispatch_queue_t queue3;
+#endif
+
+@end
+@implementation MulticastDelegateTestBase
+
+- (void)setUp {
+    self.multicastDelegate = (GCDMulticastDelegate <MyProtocol> *)[[GCDMulticastDelegate alloc] init];
+}
+
+@end
+
+@interface MulticastDelegateTest : MulticastDelegateTestBase
+@end
+
+@implementation MulticastDelegateTest
+
+- (void)setUp {
+    [super setUp];
+    
+    self.del1 = OCMStrictProtocolMock(@protocol(MyProtocol));
+    self.del2 = OCMStrictProtocolMock(@protocol(MyProtocol));
+    self.del3 = OCMStrictProtocolMock(@protocol(MyProtocol));
+    
+    self.queue1 = dispatch_queue_create("(1  )", NULL);
+    self.queue2 = dispatch_queue_create("( 2 )", NULL);
+    self.queue3 = dispatch_queue_create("(  3)", NULL);
+    
+    [self.multicastDelegate addDelegate:self.del1 delegateQueue:self.queue1];
+    [self.multicastDelegate addDelegate:self.del2 delegateQueue:self.queue2];
+    [self.multicastDelegate addDelegate:self.del3 delegateQueue:self.queue3];
+}
+
+-(void)tearDown
+{
+#if !OS_OBJECT_USE_OBJC
+    dispatch_release(self.queue1);
+    dispatch_release(self.queue2);
+    dispatch_release(self.queue3);
+#endif
+}
+
+- (void)testDidSomething
+{
+    OCMExpect([self.del1 didSomething]);
+    OCMExpect([self.del2 didSomething]);
+    OCMExpect([self.del3 didSomething]);
+    
+    [self.multicastDelegate didSomething];
+
+    OCMVerifyAllWithDelay(self.del1, 0.05);
+    OCMVerifyAll(self.del2);
+    OCMVerifyAll(self.del3);
+}
+
+- (void) testDidSomethingElse
+{
+    OCMExpect([self.del1 didSomethingElse:YES]);
+    OCMExpect([self.del2 didSomethingElse:YES]);
+    OCMExpect([self.del3 didSomethingElse:YES]);
+    
+    [self.multicastDelegate didSomethingElse:YES];
+    
+    OCMVerifyAllWithDelay(self.del1, 0.05);
+    OCMVerifyAll(self.del2);
+    OCMVerifyAll(self.del3);
+}
+
+- (void) testFoundString
+{
+    OCMExpect([self.del1 foundString:@"I like cheese"]);
+    OCMExpect([self.del2 foundString:@"I like cheese"]);
+    OCMExpect([self.del3 foundString:@"I like cheese"]);
+    
+    [self.multicastDelegate foundString:@"I like cheese"];
+    
+    OCMVerifyAllWithDelay(self.del1, 0.05);
+    OCMVerifyAll(self.del2);
+    OCMVerifyAll(self.del3);
+}
+
+- (void) testFoundStringAndNumber
+{
+    OCMExpect([self.del1 foundString:@"The lucky number is" andNumber:@15]);
+    OCMExpect([self.del2 foundString:@"The lucky number is" andNumber:@15]);
+    OCMExpect([self.del3 foundString:@"The lucky number is" andNumber:@15]);
+    
+    [self.multicastDelegate foundString:@"The lucky number is" andNumber:@15];
+
+    OCMVerifyAllWithDelay(self.del1, 0.05);
+    OCMVerifyAll(self.del2);
+    OCMVerifyAll(self.del3);
+}
+
+- (void)testDelegateEnumerator
+{
+    GCDMulticastDelegateEnumerator *delegateEnum = [self.multicastDelegate delegateEnumerator];
+    
+    id del;
+    dispatch_queue_t dq;
+    
+    BOOL del1Seen = false;
+    BOOL del2Seen = false;
+    BOOL del3Seen = false;
+    
+    while ([delegateEnum getNextDelegate:&del delegateQueue:&dq forSelector:@selector(didSomething)])
+    {
+        if (del == self.del1) {
+            XCTAssertEqual(dq, self.queue1);
+            del1Seen = true;
+        } else if (del == self.del2) {
+            XCTAssertEqual(dq, self.queue2);
+            del2Seen = true;
+        } else if (del == self.del3) {
+            XCTAssertEqual(dq, self.queue3);
+            del3Seen = true;
+        } else {
+            XCTFail(@"Unexpected delegate");
+        }
+    }
+    
+    XCTAssertTrue(del1Seen);
+    XCTAssertTrue(del2Seen);
+    XCTAssertTrue(del3Seen);
+}
+
+@end
+
+// NSProxy doesn't work correctly with weak references, so this test needs a different approach.
+
+@interface MyMock : NSObject <MyProtocol>
+@end
+@implementation MyMock
+
+- (void)didSomething { }
+- (void)didSomethingElse:(BOOL)flag { }
+- (void)foundString:(NSString *)str { }
+- (void)foundString:(NSString *)str andNumber:(NSNumber *)num { }
+
+@end
+
+@interface MulticastDelegateWeakReferenceTest : MulticastDelegateTestBase
+@end
+
+@implementation MulticastDelegateWeakReferenceTest
+
+- (void)setUp {
+    [super setUp];
+    
+    self.del1 = [[MyMock alloc] init];
+    self.del2 = [[MyMock alloc] init];
+    self.del3 = [[MyMock alloc] init];
+    
+    self.queue1 = dispatch_queue_create("(1  )", NULL);
+    self.queue2 = dispatch_queue_create("( 2 )", NULL);
+    self.queue3 = dispatch_queue_create("(  3)", NULL);
+    
+    [self.multicastDelegate addDelegate:self.del1 delegateQueue:self.queue1];
+    [self.multicastDelegate addDelegate:self.del2 delegateQueue:self.queue2];
+    [self.multicastDelegate addDelegate:self.del3 delegateQueue:self.queue3];
+}
+
+- (void)testThatDelegateReferencesAreWeak
+{
+    XCTAssertEqual([self.multicastDelegate countForSelector:@selector(description)], 3);
+    
+    self.del1 = nil;
+    
+    XCTAssertEqual([self.multicastDelegate countForSelector:@selector(description)], 2);
+}
+
+@end


### PR DESCRIPTION
Done:

- Upgrade GCDAsyncSocket to 7.4.1
- Gets old test projects passing in Xcode 6.3 (except for the FacebookTest, which needs to be rewritten using a newer version of the SDK)
- Started porting existing tests to a new iOS test target using XCTest + OCMock
- Changed -[XMPPCapabilities hashCapabilitiesFromQuery] to a class method to make it more testable

Todo:

- Travis scripts
- Finish porting existing assertion-driven tests
- Review the tests without assertion, figure out what they are testing, and rewrite them
- New MacOS test target