### PR TITLE
Allow a different username to be used for authentication

### DIFF
--- a/Authentication/Digest-MD5/XMPPDigestMD5Authentication.m
+++ b/Authentication/Digest-MD5/XMPPDigestMD5Authentication.m
@@ -71,9 +71,15 @@
 
 - (id)initWithStream:(XMPPStream *)stream password:(NSString *)inPassword
 {
+	return [self initWithStream:stream username:nil password:inPassword];
+}
+
+- (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword
+{
 	if ((self = [super init]))
 	{
 		xmppStream = stream;
+		username = inUsername;
 		password = inPassword;
 	}
 	return self;
@@ -140,7 +146,10 @@
 	if (cnonce == nil)
 		cnonce = [XMPPStream generateUUID];
 	
-	username = [myJID user];
+	if (username == nil)
+	{
+		username = [myJID user];
+	}
 	
 	// Create and send challenge response element
 	

--- a/Authentication/Plain/XMPPPlainAuthentication.h
+++ b/Authentication/Plain/XMPPPlainAuthentication.h
@@ -9,6 +9,13 @@
 // 
 // See XMPPSASLAuthentication.h for more information.
 
+/**
+ * Use this init method if the username used for authentication does not match the user part of the JID.
+ * If inUsername is nil, the user part of the JID will be used. The standard init method will use the
+ * user part of the JID as the username.
+**/
+- (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword;
+
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Authentication/Plain/XMPPPlainAuthentication.h
+++ b/Authentication/Plain/XMPPPlainAuthentication.h
@@ -9,13 +9,6 @@
 // 
 // See XMPPSASLAuthentication.h for more information.
 
-/**
- * Use this init method if the username used for authentication does not match the user part of the JID.
- * If inUsername is nil, the user part of the JID will be used. The standard init method will use the
- * user part of the JID as the username.
-**/
-- (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword;
-
 @end
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Authentication/Plain/XMPPPlainAuthentication.m
+++ b/Authentication/Plain/XMPPPlainAuthentication.m
@@ -25,6 +25,7 @@
 	__unsafe_unretained XMPPStream *xmppStream;
   #endif
 	
+	NSString *username;
 	NSString *password;
 }
 
@@ -33,14 +34,20 @@
 	return @"PLAIN";
 }
 
-- (id)initWithStream:(XMPPStream *)stream password:(NSString *)inPassword
+- (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword
 {
 	if ((self = [super init]))
 	{
 		xmppStream = stream;
+		username = inUsername;
 		password = inPassword;
 	}
 	return self;
+}
+
+- (id)initWithStream:(XMPPStream *)stream password:(NSString *)inPassword
+{
+	return [self initWithStream:stream username:nil password:inPassword];
 }
 
 - (BOOL)start:(NSError **)errPtr
@@ -54,9 +61,13 @@
 	// authcid: authentication identity (username)
 	// passwd : password for authcid
 	
-	NSString *username = [xmppStream.myJID user];
+	NSString *authUsername = username;
+	if (!authUsername)
+	{
+		authUsername = [xmppStream.myJID user];
+	}
 	
-	NSString *payload = [NSString stringWithFormat:@"\0%@\0%@", username, password];
+	NSString *payload = [NSString stringWithFormat:@"\0%@\0%@", authUsername, password];
 	NSString *base64 = [[payload dataUsingEncoding:NSUTF8StringEncoding] xmpp_base64Encoded];
 	
 	// <auth xmlns="urn:ietf:params:xml:ns:xmpp-sasl" mechanism="PLAIN">Base-64-Info</auth>

--- a/Authentication/Plain/XMPPPlainAuthentication.m
+++ b/Authentication/Plain/XMPPPlainAuthentication.m
@@ -34,6 +34,11 @@
 	return @"PLAIN";
 }
 
+- (id)initWithStream:(XMPPStream *)stream password:(NSString *)inPassword
+{
+	return [self initWithStream:stream username:nil password:inPassword];
+}
+
 - (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword
 {
 	if ((self = [super init]))
@@ -43,11 +48,6 @@
 		password = inPassword;
 	}
 	return self;
-}
-
-- (id)initWithStream:(XMPPStream *)stream password:(NSString *)inPassword
-{
-	return [self initWithStream:stream username:nil password:inPassword];
 }
 
 - (BOOL)start:(NSError **)errPtr

--- a/Authentication/SCRAM-SHA-1/XMPPSCRAMSHA1Authentication.m
+++ b/Authentication/SCRAM-SHA-1/XMPPSCRAMSHA1Authentication.m
@@ -65,20 +65,20 @@ static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
 
 - (id)initWithStream:(XMPPStream *)stream password:(NSString *)password
 {
-	return [self initWithStream:stream username:nil password:inPassword];
+	return [self initWithStream:stream username:nil password:password];
 }
 
-- (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword
+- (id)initWithStream:(XMPPStream *)stream username:(NSString *)username password:(NSString *)password
 {
     if ((self = [super init])) {
         xmppStream = stream;
-        if (inUsername)
+        if (username)
         {
-        	_username = inUsername;
+            _username = username;
         }
         else
         {
-			_username = [XMPPStringPrep prepNode:[xmppStream.myJID user]];
+            _username = [XMPPStringPrep prepNode:[xmppStream.myJID user]];
         }
         _password = [XMPPStringPrep prepPassword:password];
         _hashAlgorithm = kCCHmacAlgSHA1;

--- a/Authentication/SCRAM-SHA-1/XMPPSCRAMSHA1Authentication.m
+++ b/Authentication/SCRAM-SHA-1/XMPPSCRAMSHA1Authentication.m
@@ -65,9 +65,21 @@ static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
 
 - (id)initWithStream:(XMPPStream *)stream password:(NSString *)password
 {
+	return [self initWithStream:stream username:nil password:inPassword];
+}
+
+- (id)initWithStream:(XMPPStream *)stream username:(NSString *)inUsername password:(NSString *)inPassword
+{
     if ((self = [super init])) {
         xmppStream = stream;
-        _username = [XMPPStringPrep prepNode:[xmppStream.myJID user]];
+        if (inUsername)
+        {
+        	_username = inUsername;
+        }
+        else
+        {
+			_username = [XMPPStringPrep prepNode:[xmppStream.myJID user]];
+        }
         _password = [XMPPStringPrep prepPassword:password];
         _hashAlgorithm = kCCHmacAlgSHA1;
     }

--- a/Authentication/XMPPSASLAuthentication.h
+++ b/Authentication/XMPPSASLAuthentication.h
@@ -59,6 +59,13 @@ typedef NS_ENUM(NSInteger, XMPPHandleAuthResponse) {
 - (id)initWithStream:(XMPPStream *)stream password:(NSString *)password;
 
 /**
+ * Use this init method if the username used for authentication does not match the user part of the JID.
+ * If username is nil, the user part of the JID will be used.
+ * The standard init method uses this init method, passing nil for the username.
+**/
+- (id)initWithStream:(XMPPStream *)stream username:(NSString *)username password:(NSString *)password;
+
+/**
  * Attempts to start the authentication process.
  * The auth mechanism should send whatever stanzas are needed to begin the authentication process.
  * 


### PR DESCRIPTION
The username used for authentication may not be the same as the user part of a JID (see https://tools.ietf.org/html/rfc6120#section-6.3.7). This PR allows a different username to be used (if needed) while still defaulting to use the user part of the JID.