### PR TITLE
Support for XMPP URIs (XEP-0147 / RFC 5122)

### DIFF
--- a/Extensions/XEP-0147/XMPPURI.h
+++ b/Extensions/XEP-0147/XMPPURI.h
@@ -1,0 +1,55 @@
+//
+//  XMPPURI.h
+//  ChatSecure
+//
+//  Created by Christopher Ballinger on 5/15/15.
+//  Copyright (c) 2015 Chris Ballinger. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "XMPPJID.h"
+
+/** 
+ *  For parsing and creating XMPP URIs RFC5122/XEP-0147
+ *  e.g. xmpp:username@domain.com?subscribe 
+ *  http://www.xmpp.org/extensions/xep-0147.html
+ */
+@interface XMPPURI : NSObject
+
+@property (nonatomic, strong, readonly) XMPPJID *jid;
+
+/** 
+ * XMPP query action. e.g. subscribe
+ * For example, the query action below would be 'subscribe'
+ *    xmpp:romeo@montague.net?subscribe
+ * For full list: http://xmpp.org/registrar/querytypes.html
+ */
+@property (nonatomic, strong, readonly) NSString *queryAction;
+
+/**
+ * XMPP query parameters. e.g. subject=Test
+ *
+ * For example the query parameters for
+ *     xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+ * would be
+ * {"subject": "Test Message",
+ *  "body": "Here's a test message"}
+ */
+@property (nonatomic, strong, readonly) NSDictionary *queryParameters;
+
+/** 
+ * Generates URI string from jid, queryAction, and queryParameters
+ * e.g. xmpp:romeo@montague.net?subscribe 
+ */
+- (NSString*) uriString;
+
+// Parsing XMPP URIs
+- (instancetype) initWithURL:(NSURL*)url;
+- (instancetype) initWithURIString:(NSString*)uriString;
+
+// Creating XMPP URIs
+- (instancetype) initWithJID:(XMPPJID*)jid
+                 queryAction:(NSString*)queryAction
+             queryParameters:(NSDictionary*)queryParameters;
+
+@end

--- a/Extensions/XEP-0147/XMPPURI.h
+++ b/Extensions/XEP-0147/XMPPURI.h
@@ -1,6 +1,6 @@
 //
 //  XMPPURI.h
-//  ChatSecure
+//  XMPPFramework
 //
 //  Created by Christopher Ballinger on 5/15/15.
 //  Copyright (c) 2015 Chris Ballinger. All rights reserved.

--- a/Extensions/XEP-0147/XMPPURI.h
+++ b/Extensions/XEP-0147/XMPPURI.h
@@ -16,7 +16,21 @@
  */
 @interface XMPPURI : NSObject
 
+/**
+ * User JID. e.g. romeo@montague.net
+ * Example: xmpp:romeo@montague.net
+ */
 @property (nonatomic, strong, readonly) XMPPJID *jid;
+
+/**
+ * Account JID. (Optional)
+ * Used to specify an account with which to perform an action.
+ * For example 'guest@example.com' would be the authority portion of
+ *    xmpp://guest@example.com/support@example.com?message
+ * so the application would show a dialog with an outgoing message
+ * to support@example.com from the user's account guest@example.com.
+ */
+@property (nonatomic, strong, readonly) XMPPJID *accountJID;
 
 /** 
  * XMPP query action. e.g. subscribe

--- a/Extensions/XEP-0147/XMPPURI.m
+++ b/Extensions/XEP-0147/XMPPURI.m
@@ -1,0 +1,91 @@
+//
+//  XMPPURI.m
+//  ChatSecure
+//
+//  Created by Christopher Ballinger on 5/15/15.
+//  Copyright (c) 2015 Chris Ballinger. All rights reserved.
+//
+
+#import "XMPPURI.h"
+
+@implementation XMPPURI
+
+- (instancetype) initWithURIString:(NSString *)uriString {
+    if (self = [super init]) {
+        [self parseURIString:uriString];
+    }
+    return self;
+}
+
+- (instancetype) initWithURL:(NSURL *)url {
+    if (self = [self initWithURIString:url.absoluteString]) {
+    }
+    return self;
+}
+
+- (instancetype) initWithJID:(XMPPJID*)jid
+                 queryAction:(NSString*)queryAction
+             queryParameters:(NSDictionary*)queryParameters {
+    if (self = [super init]) {
+        _jid = [jid copy];
+        _queryAction = [queryAction copy];
+        _queryParameters = [queryParameters copy];
+    }
+    return self;
+}
+
+- (NSString*) uriString {
+    NSMutableString *uriString = [NSMutableString stringWithFormat:@"xmpp:%@", self.jid.bare];
+    if (self.queryAction) {
+        [uriString appendFormat:@"?%@", self.queryAction];
+    }
+    [self.queryParameters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, BOOL *stop) {
+        [uriString appendFormat:@";%@=%@", key, [obj stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    }];
+    return uriString;
+}
+
+- (void) parseURIString:(NSString*)uriString {
+    // Fix potentially malformed URIs
+    if ([uriString containsString:@"://"]) {
+        uriString = [uriString stringByReplacingOccurrencesOfString:@"://" withString:@":" options:0 range:NSMakeRange(0, uriString.length)];
+    }
+    NSArray *uriComponents = [uriString componentsSeparatedByString:@":"];
+    NSString *scheme = nil;
+    NSString *jidString = nil;
+    
+    if (uriComponents.count >= 2) {
+        scheme = uriComponents[0];
+        NSString *path = uriComponents[1];
+        if ([path containsString:@"?"]) {
+            NSArray *queryComponents = [path componentsSeparatedByString:@"?"];
+            jidString = queryComponents[0];
+            NSString *query = queryComponents[1];
+            NSArray *queryKeys = [query componentsSeparatedByString:@";"];
+            
+            NSMutableDictionary *queryParameters = [NSMutableDictionary dictionaryWithCapacity:queryKeys.count];
+            [queryKeys enumerateObjectsUsingBlock:^(NSString *queryItem, NSUInteger idx, BOOL *stop) {
+                if (idx == 0) {
+                    _queryAction = queryItem;
+                } else {
+                    NSArray *keyValue = [queryItem componentsSeparatedByString:@"="];
+                    if (keyValue.count == 2) {
+                        NSString *key = keyValue[0];
+                        NSString *value = [keyValue[1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                        if (key && value) {
+                            queryParameters[key] = value;
+                        }
+                    }
+                }
+            }];
+            _queryParameters = queryParameters;
+        } else {
+            jidString = path;
+        }
+    }
+    if (jidString) {
+        _jid = [XMPPJID jidWithString:jidString];
+    }
+}
+
+@end

--- a/Extensions/XEP-0147/XMPPURI.m
+++ b/Extensions/XEP-0147/XMPPURI.m
@@ -1,6 +1,6 @@
 //
 //  XMPPURI.m
-//  ChatSecure
+//  XMPPFramework
 //
 //  Created by Christopher Ballinger on 5/15/15.
 //  Copyright (c) 2015 Chris Ballinger. All rights reserved.

--- a/Xcode/Testing2/Podfile
+++ b/Xcode/Testing2/Podfile
@@ -1,7 +1,8 @@
 xcodeproj 'XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj'
 
 # Uncomment this line to define a global platform for your project
-# platform :ios, '6.0'
+
+platform :ios, '6.0'
 
 target 'XMPPFrameworkTests' do
 	

--- a/Xcode/Testing2/Podfile.lock
+++ b/Xcode/Testing2/Podfile.lock
@@ -1,0 +1,10 @@
+PODS:
+  - OCMock (3.1.2)
+
+DEPENDENCIES:
+  - OCMock (~> 3.1)
+
+SPEC CHECKSUMS:
+  OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
+
+COCOAPODS: 0.37.2

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		9EF4C7CE1AE2C4480019F001 /* libresolv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */; };
 		9EF4C7D31AE2C4CC0019F001 /* EncodeDecodeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */; };
 		9EF4C7D51AE2C6100019F001 /* MulticastDelegateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF4C7D41AE2C6100019F001 /* MulticastDelegateTest.m */; };
+		D9A3CB311B27F0C8000A50C6 /* XMPPURI.m in Sources */ = {isa = PBXBuildFile; fileRef = D9A3CB301B27F0C8000A50C6 /* XMPPURI.m */; };
+		D9A3CB331B27F0FD000A50C6 /* XMPPURITests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9A3CB321B27F0FD000A50C6 /* XMPPURITests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -216,6 +218,9 @@
 		9EF4C7CD1AE2C4480019F001 /* libresolv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libresolv.dylib; path = usr/lib/libresolv.dylib; sourceTree = SDKROOT; };
 		9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncodeDecodeTest.m; sourceTree = "<group>"; };
 		9EF4C7D41AE2C6100019F001 /* MulticastDelegateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MulticastDelegateTest.m; sourceTree = "<group>"; };
+		D9A3CB2F1B27F0C8000A50C6 /* XMPPURI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPURI.h; sourceTree = "<group>"; };
+		D9A3CB301B27F0C8000A50C6 /* XMPPURI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPURI.m; sourceTree = "<group>"; };
+		D9A3CB321B27F0FD000A50C6 /* XMPPURITests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPURITests.m; sourceTree = "<group>"; };
 		E12FE78966D1CF605B0A4F20 /* libPods-XMPPFrameworkTestsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-XMPPFrameworkTestsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -290,6 +295,7 @@
 		9E56CB421AE2F808008CE1D5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				D9A3CB2E1B27F0C8000A50C6 /* XEP-0147 */,
 				9E56CB531AE2F81E008CE1D5 /* CoreDataStorage */,
 				9E56CB431AE2F817008CE1D5 /* XEP-0115 */,
 			);
@@ -382,6 +388,7 @@
 		9EF4C5BD1AE2C2C50019F001 /* XMPPFrameworkTestsTests */ = {
 			isa = PBXGroup;
 			children = (
+				D9A3CB321B27F0FD000A50C6 /* XMPPURITests.m */,
 				9EF4C7D21AE2C4CC0019F001 /* EncodeDecodeTest.m */,
 				9EF4C7D41AE2C6100019F001 /* MulticastDelegateTest.m */,
 				9EF4C5BE1AE2C2C50019F001 /* Supporting Files */,
@@ -657,6 +664,15 @@
 			path = Private;
 			sourceTree = "<group>";
 		};
+		D9A3CB2E1B27F0C8000A50C6 /* XEP-0147 */ = {
+			isa = PBXGroup;
+			children = (
+				D9A3CB2F1B27F0C8000A50C6 /* XMPPURI.h */,
+				D9A3CB301B27F0C8000A50C6 /* XMPPURI.m */,
+			);
+			path = "XEP-0147";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -888,6 +904,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				9EF4C7D31AE2C4CC0019F001 /* EncodeDecodeTest.m in Sources */,
+				D9A3CB331B27F0FD000A50C6 /* XMPPURITests.m in Sources */,
+				D9A3CB311B27F0C8000A50C6 /* XMPPURI.m in Sources */,
 				9EF4C7D51AE2C6100019F001 /* MulticastDelegateTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/XMPPURITests.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/XMPPURITests.m
@@ -44,6 +44,37 @@
     XCTAssertEqualObjects(queryParameters, uriParsing.queryParameters);
 }
 
+- (void) testURIString {
+    NSString *uriString = @"xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message";
+    XMPPURI *uri = [[XMPPURI alloc] initWithURIString:uriString];
+    NSString *outURIString = uri.uriString;
+    XCTAssertEqualObjects(uriString, outURIString);
+}
+
+- (void) testXMPPAuthority {
+    NSString *testString = @"xmpp://guest@example.com/support@example.com?message";
+    NSString *authority = @"guest@example.com";
+    NSString *user = @"support@example.com";
+    NSString *action = @"message";
+    NSString *uriString = [NSString stringWithFormat:@"xmpp://%@/%@?%@", authority, user, action];
+    XCTAssertEqualObjects(testString, uriString);
+    XMPPURI *uri = [[XMPPURI alloc] initWithURIString:uriString];
+    XCTAssertEqualObjects(uri.jid.bare, user);
+    XCTAssertEqualObjects(uri.accountJID.bare, authority);
+}
+
+- (void) testXMPPAuthorityWithResource {
+    NSString *testString = @"xmpp://guest@example.com/support@example.com/resource?message";
+    NSString *authority = @"guest@example.com";
+    NSString *user = @"support@example.com/resource";
+    NSString *action = @"message";
+    NSString *uriString = [NSString stringWithFormat:@"xmpp://%@/%@?%@", authority, user, action];
+    XCTAssertEqualObjects(testString, uriString);
+    XMPPURI *uri = [[XMPPURI alloc] initWithURIString:uriString];
+    XCTAssertEqualObjects(uri.jid.full, user);
+    XCTAssertEqualObjects(uri.accountJID.bare, authority);
+}
+
 - (void) testSubscribeWithOTR {
     XMPPJID *jid = [XMPPJID jidWithString:@"romeo@montague.net"];
     NSString *queryAction = @"subscribe";

--- a/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/XMPPURITests.m
+++ b/Xcode/Testing2/XMPPFrameworkTests/XMPPFrameworkTestsTests/XMPPURITests.m
@@ -1,0 +1,66 @@
+//
+//  XMPPURITests.m
+//  ChatSecure
+//
+//  Created by Christopher Ballinger on 6/9/15.
+//  Copyright (c) 2015 Chris Ballinger. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "XMPPURI.h"
+
+@interface XMPPURITests : XCTestCase
+
+@end
+
+@implementation XMPPURITests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+
+- (void) testXMPPURI {
+    XMPPJID *jid = [XMPPJID jidWithString:@"romeo@montague.net"];
+    NSString *queryAction = @"message";
+    NSDictionary *queryParameters = @{@"subject": @"Test Message",
+                                      @"body": @"Here's a test message"};
+    XMPPURI *uriGeneration = [[XMPPURI alloc] initWithJID:jid queryAction:queryAction queryParameters:queryParameters];
+    
+    NSString *uriString = [uriGeneration uriString];
+    NSURL *url = [NSURL URLWithString:uriString];
+    
+    XMPPURI *uriParsing = [[XMPPURI alloc] initWithURL:url];
+    
+    XCTAssertEqualObjects(jid.bare, uriParsing.jid.bare);
+    XCTAssertEqualObjects(queryAction, uriParsing.queryAction);
+    XCTAssertEqualObjects(queryParameters, uriParsing.queryParameters);
+}
+
+- (void) testSubscribeWithOTR {
+    XMPPJID *jid = [XMPPJID jidWithString:@"romeo@montague.net"];
+    NSString *queryAction = @"subscribe";
+    NSString *fingerprint = @"8FBB10D4A2B73FAE935FF3AEBA5EFFE29A98966F";
+    NSString *fingerprintKey = @"otr-fingerprint";
+    NSDictionary *queryParameters = @{fingerprintKey: fingerprint};
+    XMPPURI *uriGeneration = [[XMPPURI alloc] initWithJID:jid queryAction:queryAction queryParameters:queryParameters];
+    
+    NSString *uriString = [uriGeneration uriString];
+    NSURL *url = [NSURL URLWithString:uriString];
+    
+    XMPPURI *uriParsing = [[XMPPURI alloc] initWithURL:url];
+    
+    XCTAssertEqualObjects(jid.bare, uriParsing.jid.bare);
+    XCTAssertEqualObjects(queryAction, uriParsing.queryAction);
+    XCTAssertEqualObjects(queryParameters, uriParsing.queryParameters);
+    XCTAssertEqualObjects(fingerprint, uriParsing.queryParameters[fingerprintKey]);
+}
+
+@end


### PR DESCRIPTION
This adds basic support for generating and parsing XMPP URIs defined in [XEP-0147](http://xmpp.org/extensions/xep-0147.html) and [RFC 5122](http://tools.ietf.org/html/rfc5122). I also added a few tests in the XCTest "Testing2" area.