### PR TITLE
Fixed bug when mostRecentMessageTimestampForRoom returns nil

### DIFF
--- a/Extensions/XEP-0045/CoreDataStorage/XMPPRoomCoreDataStorage.m
+++ b/Extensions/XEP-0045/CoreDataStorage/XMPPRoomCoreDataStorage.m
@@ -818,11 +818,11 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 			NSString *streamBareJidStr = [[self myJIDForXMPPStream:xmppStream] bare];
 			
 			NSString *predicateFormat = @"roomJIDStr == %@ AND streamBareJidStr == %@";
-			predicate = [NSPredicate predicateWithFormat:predicateFormat, roomJID, streamBareJidStr];
+			predicate = [NSPredicate predicateWithFormat:predicateFormat, roomJID.bare, streamBareJidStr];
 		}
 		else
 		{
-			predicate = [NSPredicate predicateWithFormat:@"roomJIDStr == %@", roomJID];
+			predicate = [NSPredicate predicateWithFormat:@"roomJIDStr == %@", roomJID.bare];
 		}
 		
 		NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"localTimestamp" ascending:NO];


### PR DESCRIPTION
XMPPJID * roomJID is used in this method for predicate building. Due to this method returns nil. Method returns what is expected if NSString * roomJID.bare is used.