### PR TITLE
fix XEP-0066 message namespace

### DIFF
--- a/Extensions/XEP-0066/XMPPMessage+XEP_0066.m
+++ b/Extensions/XEP-0066/XMPPMessage+XEP_0066.m
@@ -6,7 +6,7 @@
 #endif
 
 #define NAME_OUT_OF_BAND @"x"
-#define XMLNS_OUT_OF_BAND @"jabber:iq:oob"
+#define XMLNS_OUT_OF_BAND @"jabber:x:oob"
 
 @implementation XMPPMessage (XEP_0066)
 


### PR DESCRIPTION
`jabber:iq:oob` used with `XMPPIQ`, but `jabber:x:oob` should be used with `XMPPMessage`