### PR TITLE
Add timeout to XMPPAutoTime

### DIFF
--- a/Extensions/XEP-0202/XMPPAutoTime.h
+++ b/Extensions/XEP-0202/XMPPAutoTime.h
@@ -113,6 +113,7 @@
 @optional
 
 - (void)xmppAutoTime:(XMPPAutoTime *)sender didUpdateTimeDifference:(NSTimeInterval)timeDifference;
+- (void)xmppAutoTimeDidNotReceiveResponseDueToTimeout:(XMPPAutoTime *)sender;
 
 @end
 

--- a/Extensions/XEP-0202/XMPPAutoTime.m
+++ b/Extensions/XEP-0202/XMPPAutoTime.m
@@ -400,11 +400,11 @@
 
 - (void)xmppTime:(XMPPTime *)sender didNotReceiveResponse:(NSString *)queryID dueToTimeout:(NSTimeInterval)timeout
 {
-	XMPPLogTrace();
-	
-	awaitingQueryResponse = NO;
-	
-	// Nothing to do here really. Most likely the server doesn't support XEP-0202.
+    XMPPLogTrace();
+    
+    awaitingQueryResponse = NO;
+    
+    [multicastDelegate xmppAutoTimeDidNotReceiveResponseDueToTimeout:self];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Utilities/XMPPSRVResolver.m
+++ b/Utilities/XMPPSRVResolver.m
@@ -227,7 +227,7 @@ NSString *const XMPPSRVResolverErrorDomain = @"XMPPSRVResolverErrorDomain";
 					srvRecord = nil;
 				}
 				
-			} while(srvRecord && (srvRecord.priority == initialPriority));
+			} while(srvRecord && (srvRecord.priority >= initialPriority));
 			
 			/* Then choose a uniform random number between 0 and the sum computed
 			 * (inclusive), and select the RR whose running sum value is the


### PR DESCRIPTION
Objects using XMPPAutoTime can now also track when the request failed in order to react to this event