### PR TITLE
Change cases for avoid errors when compiling for case sensitive filesystems

### DIFF
--- a/Core/XMPPLogging.h
+++ b/Core/XMPPLogging.h
@@ -59,7 +59,7 @@
  * If you created your project with a previous version of Xcode, you may need to add the DEBUG macro manually.
 **/
 
-#import "CocoaLumberJack/DDLog.h"
+#import "CocoaLumberjack/DDLog.h"
 
 // Global flag to enable/disable logging throughout the entire xmpp framework.
 

--- a/Extensions/XEP-0054/CoreDataStorage/XMPPvCardTempCoreDataStorageObject.h
+++ b/Extensions/XEP-0054/CoreDataStorage/XMPPvCardTempCoreDataStorageObject.h
@@ -10,7 +10,7 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 
-#import "XMPPvcardTemp.h"
+#import "XMPPvCardTemp.h"
 
 @class XMPPvCardCoreDataStorageObject;
 


### PR DESCRIPTION
Working directly with the device is not a problem, but when trying to use the simulator the framework does not compile due to cases and a case sensitive filesystem as in my case.

For further data, I'm using CocoaPods for Swift with the use_frameworks! flag.