### PR TITLE
XEP-0184 - Message delivery receipts while offline

### DIFF
--- a/Extensions/XEP-0184/XMPPMessage+XEP_0184.m
+++ b/Extensions/XEP-0184/XMPPMessage+XEP_0184.m
@@ -37,6 +37,12 @@
 	
 	NSXMLElement *message = [NSXMLElement elementWithName:@"message"];
 	
+    NSString *type = [self type];
+    
+    if (type) {
+        [message addAttributeWithName:@"type" stringValue:type];
+    }
+    
 	NSString *to = [self fromStr];
 	if (to)
 	{


### PR DESCRIPTION
Hi

XEP-0184 is working fine while online. But If the message is delivered while the sender is offline the sender can't be notified when he/she is online again. Then I figured out the "type" attribute is missing from the receipt response.

By the way I am using Openfire as XMPP server.