### PR TITLE
XEP-0184 Fix For Group Chat

### DIFF
--- a/Extensions/XEP-0184/XMPPMessage+XEP_0184.m
+++ b/Extensions/XEP-0184/XMPPMessage+XEP_0184.m
@@ -1,5 +1,6 @@
 #import "XMPPMessage+XEP_0184.h"
 #import "NSXMLElement+XMPP.h"
+#import "XMPPMessage+XEP0045.h"
 
 
 @implementation XMPPMessage (XEP_0184)
@@ -43,7 +44,13 @@
         [message addAttributeWithName:@"type" stringValue:type];
     }
     
-	NSString *to = [self fromStr];
+    NSString *to = [self fromStr];
+    
+    if([self isGroupChatMessage]) {
+        to = [[self from] bare];
+        [message addAttributeWithName:@"type" stringValue:@"groupchat"];
+    }
+    
 	if (to)
 	{
 		[message addAttributeWithName:@"to" stringValue:to];


### PR DESCRIPTION
Fix:
- Added type
- Bare JID (without the resource) instead of the full JID string
