### PR TITLE
generate shorter UUIDs (base64 encoded format)

### DIFF
--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -712,8 +712,11 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
  * UUIDs (Universally Unique Identifiers) may also be known as GUIDs (Globally Unique Identifiers).
  * 
  * The UUID is generated using the CFUUID library, which generates a unique 128 bit value.
- * The uuid is then translated into a string using the standard format for UUIDs:
- * "68753A44-4D6F-1226-9C60-0050E4C00067"
+ * It is then translated into a 22 character string using its URL friendly
+ * base64 encoded format: without padding (=) and replacing the following characters
+ * ('+' -> '-') and ('/' -> '_')
+ *
+ * e.g. "GHpy_-yfSf--It29T31fhw"   (from base64 form: GHpy/+yfSf++It29T31fhw==)
  * 
  * This method is most commonly used to generate a unique id value for an xmpp element.
 **/

--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -5001,15 +5001,28 @@ enum XMPPStreamConfig
 
 + (NSString *)generateUUID
 {
-	NSString *result = nil;
-	
-	CFUUIDRef uuid = CFUUIDCreate(NULL);
-	if (uuid)
-	{
-		result = (__bridge_transfer NSString *)CFUUIDCreateString(NULL, uuid);
-		CFRelease(uuid);
-	}
-	
+    CFUUIDRef uuid = CFUUIDCreate(NULL);
+    if (!uuid) return nil;
+    
+    CFUUIDBytes bytes = CFUUIDGetUUIDBytes(uuid);
+    CFRelease((CFTypeRef)uuid);
+    
+    NSData *data = [NSData dataWithBytes:&bytes length:sizeof(bytes)];
+    NSString *base64;
+    
+    if ([data respondsToSelector:@selector(base64EncodedStringWithOptions:)])
+    {
+        base64 = [data base64EncodedStringWithOptions:0]; // iOS 7+
+    }
+    else
+    {
+        base64 = [data base64Encoding]; // pre iOS7
+    }
+    
+    NSString *result = [[[base64
+                           stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
+                          stringByReplacingOccurrencesOfString:@"+" withString:@"-"]
+                         stringByReplacingOccurrencesOfString:@"=" withString:@""];
 	return result;
 }
 


### PR DESCRIPTION
see:
https://en.wikipedia.org/wiki/Globally_unique_identifier#Text_encoding