### PR TITLE
XEP-0334: Message Processing Hints

### DIFF
--- a/Extensions/XEP-0334/XMPPMessage+XEP_0334.h
+++ b/Extensions/XEP-0334/XMPPMessage+XEP_0334.h
@@ -1,0 +1,49 @@
+//
+//  XMPPMessage+XEP_0334.h
+//  Pods
+//
+//  Created by Chris Ballinger on 4/16/16.
+//
+//
+
+#import <XMPPFramework/XMPPFramework.h>
+
+typedef NS_ENUM(NSInteger, XMPPMessageStorage) {
+    /** No storage hints present */
+    XMPPMessageStorageUndefined,
+    /**
+      The <no-permanent-store/> hint informs entities that they shouldn't store the message in any permanent or semi-permanent public or private archive (such as described in Message Archiving (XEP-0136) [5] and Message Archive Management (XEP-0313) [6]) or in logs (such as chatroom logs).
+     */
+    XMPPMessageStorageNoPermanentStore,
+    /**
+      A message containing a <no-store/> hint should not be stored by a server either permanently (as above) or temporarily, e.g. for later delivery to an offline client, or to users not currently present in a chatroom.
+     */
+    XMPPMessageStorageNoStore,
+    /**
+     Messages with the <no-copy/> hint should not be copied to addresses other than the one to which it is addressed, for example through Message Carbons (XEP-0280) [7].
+     
+     This hint MUST only be included on messages addressed to full JIDs and explicitly does not override the behaviour defined in XMPP IM [8] for handling messages to bare JIDs, which may involve copying to multiple resources, or multiple occupants in a Multi-User Chat (XEP-0045) [9] room.
+     */
+    XMPPMessageStorageNoCopy,
+    /**
+      A message containing the <store/> hint that is not of type 'error' SHOULD be stored by the entity.
+     */
+    XMPPMessageStorageStore
+};
+
+/**
+ XEP-0334: Message Processing Hints
+ http://xmpp.org/extensions/xep-0334.html
+ 
+ This specification aims to solve the following common problems, and allow a sender to hint to the recipient:
+ 
+  - Whether to store a message (e.g. for archival or as an 'offline message').
+  - Whether to copy a message to other resources.
+  - Whether to store a message that would not have been stored under normal conditions
+ */
+@interface XMPPMessage (XEP_0334)
+
+-(void) setStorageHint:(XMPPMessageStorage)storageHint;
+- (XMPPMessageStorage)storageHint;
+
+@end

--- a/Extensions/XEP-0334/XMPPMessage+XEP_0334.h
+++ b/Extensions/XEP-0334/XMPPMessage+XEP_0334.h
@@ -9,8 +9,10 @@
 #import <XMPPFramework/XMPPFramework.h>
 
 typedef NS_ENUM(NSInteger, XMPPMessageStorage) {
-    /** No storage hints present */
-    XMPPMessageStorageUndefined,
+    /** 
+     Unknown storage hint. Attempting to add this is a no-op. 
+     */
+    XMPPMessageStorageUnknown,
     /**
       The <no-permanent-store/> hint informs entities that they shouldn't store the message in any permanent or semi-permanent public or private archive (such as described in Message Archiving (XEP-0136) [5] and Message Archive Management (XEP-0313) [6]) or in logs (such as chatroom logs).
      */
@@ -43,7 +45,10 @@ typedef NS_ENUM(NSInteger, XMPPMessageStorage) {
  */
 @interface XMPPMessage (XEP_0334)
 
--(void) setStorageHint:(XMPPMessageStorage)storageHint;
-- (XMPPMessageStorage)storageHint;
+/** add a storage hint to message element */
+-(void) addStorageHint:(XMPPMessageStorage)storageHint;
+
+/** Contains array of boxed XMPPMessageStorage values present in the message element. Empty array if none found. */
+- (nonnull NSArray<NSValue*>*)storageHints;
 
 @end

--- a/Extensions/XEP-0334/XMPPMessage+XEP_0334.m
+++ b/Extensions/XEP-0334/XMPPMessage+XEP_0334.m
@@ -18,7 +18,7 @@ static NSString * const kMessageNoPermanentStore = @"no-permanent-store";
 
 @implementation XMPPMessage (XEP_0334)
 
--(void) setStorageHint:(XMPPMessageStorage)storageHint {
+-(void) addStorageHint:(XMPPMessageStorage)storageHint {
     NSString *storageName = [self nameForStorageHint:storageHint];
     if (!storageName.length) {
         return;
@@ -41,6 +41,7 @@ static NSString * const kMessageNoPermanentStore = @"no-permanent-store";
             break;
         case XMPPMessageStorageNoPermanentStore:
             storage = kMessageNoPermanentStore;
+            break;
         default:
             storage = @"";
             break;
@@ -48,27 +49,24 @@ static NSString * const kMessageNoPermanentStore = @"no-permanent-store";
     return storage;
 }
 
-- (XMPPMessageStorage) storageHint {
+- (nonnull NSArray<NSValue*>*)storageHints {
     NSArray <NSXMLElement*> *elements = [self elementsForXmlns:XMLNS_STORAGE_HINTS];
-    NSXMLElement *storageElement = elements.firstObject;
-    if (!storageElement) {
-        return XMPPMessageStorageUndefined;
-    }
-    NSString *storageName = [storageElement name];
-    if (!storageName) {
-        return XMPPMessageStorageUndefined;
-    }
-    XMPPMessageStorage storageHint = XMPPMessageStorageUndefined;
-    if ([storageName isEqualToString:kMessageStore]) {
-        storageHint = XMPPMessageStorageStore;
-    } else if ([storageName isEqualToString:kMessageNoCopy]) {
-        storageHint = XMPPMessageStorageNoCopy;
-    } else if ([storageName isEqualToString:kMessageNoStore]) {
-        storageHint = XMPPMessageStorageNoStore;
-    } else if ([storageName isEqualToString:kMessageNoPermanentStore]) {
-        storageHint = XMPPMessageStorageNoPermanentStore;
-    }
-    return storageHint;
+    NSMutableArray <NSValue*> *boxedHints = [NSMutableArray arrayWithCapacity:elements.count];
+    [elements enumerateObjectsUsingBlock:^(NSXMLElement * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        XMPPMessageStorage storageHint = XMPPMessageStorageUnknown;
+        NSString *storageName = [obj name];
+        if ([storageName isEqualToString:kMessageStore]) {
+            storageHint = XMPPMessageStorageStore;
+        } else if ([storageName isEqualToString:kMessageNoCopy]) {
+            storageHint = XMPPMessageStorageNoCopy;
+        } else if ([storageName isEqualToString:kMessageNoStore]) {
+            storageHint = XMPPMessageStorageNoStore;
+        } else if ([storageName isEqualToString:kMessageNoPermanentStore]) {
+            storageHint = XMPPMessageStorageNoPermanentStore;
+        }
+        [boxedHints addObject:@(storageHint)];
+    }];
+    return boxedHints;
 }
 
 

--- a/Extensions/XEP-0334/XMPPMessage+XEP_0334.m
+++ b/Extensions/XEP-0334/XMPPMessage+XEP_0334.m
@@ -1,0 +1,76 @@
+//
+//  XMPPMessage+XEP_0334.m
+//  Pods
+//
+//  Created by Chris Ballinger on 4/16/16.
+//
+//
+
+#import "XMPPMessage+XEP_0334.h"
+#import "NSXMLElement+XMPP.h"
+
+#define XMLNS_STORAGE_HINTS @"urn:xmpp:hints"
+
+static NSString * const kMessageStore = @"store";
+static NSString * const kMessageNoCopy = @"no-copy";
+static NSString * const kMessageNoStore = @"no-store";
+static NSString * const kMessageNoPermanentStore = @"no-permanent-store";
+
+@implementation XMPPMessage (XEP_0334)
+
+-(void) setStorageHint:(XMPPMessageStorage)storageHint {
+    NSString *storageName = [self nameForStorageHint:storageHint];
+    if (!storageName.length) {
+        return;
+    }
+    NSXMLElement *storageElement = [NSXMLElement elementWithName:storageName xmlns:XMLNS_STORAGE_HINTS];
+    [self addChild:storageElement];
+}
+
+- (NSString*) nameForStorageHint:(XMPPMessageStorage)storageHint {
+    NSString *storage = nil;
+    switch (storageHint) {
+        case XMPPMessageStorageStore:
+            storage = kMessageStore;
+            break;
+        case XMPPMessageStorageNoCopy:
+            storage = kMessageNoCopy;
+            break;
+        case XMPPMessageStorageNoStore:
+            storage = kMessageNoStore;
+            break;
+        case XMPPMessageStorageNoPermanentStore:
+            storage = kMessageNoPermanentStore;
+        default:
+            storage = @"";
+            break;
+    }
+    return storage;
+}
+
+- (XMPPMessageStorage) storageHint {
+    NSArray <NSXMLElement*> *elements = [self elementsForXmlns:XMLNS_STORAGE_HINTS];
+    NSXMLElement *storageElement = elements.firstObject;
+    if (!storageElement) {
+        return XMPPMessageStorageUndefined;
+    }
+    NSString *storageName = [storageElement name];
+    if (!storageName) {
+        return XMPPMessageStorageUndefined;
+    }
+    XMPPMessageStorage storageHint = XMPPMessageStorageUndefined;
+    if ([storageName isEqualToString:kMessageStore]) {
+        storageHint = XMPPMessageStorageStore;
+    } else if ([storageName isEqualToString:kMessageNoCopy]) {
+        storageHint = XMPPMessageStorageNoCopy;
+    } else if ([storageName isEqualToString:kMessageNoStore]) {
+        storageHint = XMPPMessageStorageNoStore;
+    } else if ([storageName isEqualToString:kMessageNoPermanentStore]) {
+        storageHint = XMPPMessageStorageNoPermanentStore;
+    }
+    return storageHint;
+}
+
+
+
+@end

--- a/XMPPFramework.podspec
+++ b/XMPPFramework.podspec
@@ -311,6 +311,12 @@ ss.dependency 'XMPPFramework/Core'
 ss.prefix_header_contents = "#define HAVE_XMPP_SUBSPEC_#{name.upcase.sub('-', '_')}"
 end
 
+s.subspec 'XEP-0334' do |ss|
+ss.source_files = 'Extensions/XEP-0334/**/*.{h,m}'
+ss.dependency 'XMPPFramework/Core'
+ss.prefix_header_contents = "#define HAVE_XMPP_SUBSPEC_#{name.upcase.sub('-', '_')}"
+end
+
 s.subspec 'XEP-0335' do |ss|
 ss.source_files = 'Extensions/XEP-0335/**/*.{h,m}'
 ss.dependency 'XMPPFramework/Core'
@@ -371,6 +377,7 @@ s.subspec 'All' do |ss|
   ss.dependency 'XMPPFramework/XEP-0297'
   ss.dependency 'XMPPFramework/XEP-0308'
   ss.dependency 'XMPPFramework/XEP-0333'
+  ss.dependency 'XMPPFramework/XEP-0334'
   ss.dependency 'XMPPFramework/XEP-0335'
   ss.dependency 'XMPPFramework/XEP-0352'
   ss.dependency 'XMPPFramework/XEP-0357'

--- a/Xcode/Testing-pod/Podfile.lock
+++ b/Xcode/Testing-pod/Podfile.lock
@@ -1,5 +1,11 @@
 PODS:
-  - CocoaAsyncSocket (7.4.2)
+  - CocoaAsyncSocket (7.4.3):
+    - CocoaAsyncSocket/All (= 7.4.3)
+  - CocoaAsyncSocket/All (7.4.3):
+    - CocoaAsyncSocket/GCD
+    - CocoaAsyncSocket/RunLoop
+  - CocoaAsyncSocket/GCD (7.4.3)
+  - CocoaAsyncSocket/RunLoop (7.4.3)
   - CocoaLumberjack (2.2.0):
     - CocoaLumberjack/Default (= 2.2.0)
     - CocoaLumberjack/Extensions (= 2.2.0)
@@ -54,6 +60,7 @@ PODS:
     - XMPPFramework/XEP-0297
     - XMPPFramework/XEP-0308
     - XMPPFramework/XEP-0333
+    - XMPPFramework/XEP-0334
     - XMPPFramework/XEP-0335
     - XMPPFramework/XEP-0352
     - XMPPFramework/XEP-0357
@@ -150,6 +157,8 @@ PODS:
     - XMPPFramework/Core
   - XMPPFramework/XEP-0333 (3.6.7):
     - XMPPFramework/Core
+  - XMPPFramework/XEP-0334 (3.6.7):
+    - XMPPFramework/Core
   - XMPPFramework/XEP-0335 (3.6.7):
     - XMPPFramework/Core
   - XMPPFramework/XEP-0352 (3.6.7):
@@ -162,12 +171,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   XMPPFramework:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  CocoaAsyncSocket: f5783bdedd232d91b89769bc4b5a1580aed518ad
+  CocoaAsyncSocket: a18c75dca4b08723628a0bacca6e94803d90be91
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   KissXML: d19dd6dc65e0dc721ba92b3077b8ebdd240f1c1e
-  XMPPFramework: 53da6a70a6aa55aaaa47009b2b11ef975e3a0556
+  XMPPFramework: 830e2b2d24ab8dd59cb48d2131df28e4b30f76b3
 
 COCOAPODS: 0.39.0

--- a/Xcode/Testing-pod/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-pod/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		63F50D9E1C6020A100CA0201 /* CapabilitiesHashingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 63F50D9B1C6020A100CA0201 /* CapabilitiesHashingTest.m */; };
 		63F50D9F1C6020A100CA0201 /* EncodeDecodeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 63F50D9C1C6020A100CA0201 /* EncodeDecodeTest.m */; };
 		63F50DA01C6020A100CA0201 /* XMPPURITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63F50D9D1C6020A100CA0201 /* XMPPURITests.m */; };
+		D92C57A41CC2E0820032DE59 /* XMPPStorageHintTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D92C57A31CC2E0820032DE59 /* XMPPStorageHintTests.m */; };
 		FEFBAD9863F9EB01B6BFB0D6 /* Pods_XMPPFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B02E767684F690CBF1C43DDA /* Pods_XMPPFrameworkTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -23,6 +24,7 @@
 		63F50D9C1C6020A100CA0201 /* EncodeDecodeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EncodeDecodeTest.m; sourceTree = "<group>"; };
 		63F50D9D1C6020A100CA0201 /* XMPPURITests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPURITests.m; sourceTree = "<group>"; };
 		B02E767684F690CBF1C43DDA /* Pods_XMPPFrameworkTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_XMPPFrameworkTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D92C57A31CC2E0820032DE59 /* XMPPStorageHintTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStorageHintTests.m; sourceTree = "<group>"; };
 		F2F59A67580A9623E48523DD /* Pods-XMPPFrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-XMPPFrameworkTests/Pods-XMPPFrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -66,6 +68,7 @@
 		63F50D941C60208200CA0201 /* XMPPFrameworkTests */ = {
 			isa = PBXGroup;
 			children = (
+				D92C57A31CC2E0820032DE59 /* XMPPStorageHintTests.m */,
 				63F50D9B1C6020A100CA0201 /* CapabilitiesHashingTest.m */,
 				63F50D9C1C6020A100CA0201 /* EncodeDecodeTest.m */,
 				63F50D9D1C6020A100CA0201 /* XMPPURITests.m */,
@@ -114,7 +117,7 @@
 		63F55A531C60204300438CE2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0730;
 				TargetAttributes = {
 					63F50D911C60208100CA0201 = {
 						CreatedOnToolsVersion = 7.2;
@@ -205,6 +208,7 @@
 				63F50D9F1C6020A100CA0201 /* EncodeDecodeTest.m in Sources */,
 				637AE2E91C6AC0D50051BF1F /* XMPPPushTests.swift in Sources */,
 				63F50DA01C6020A100CA0201 /* XMPPURITests.m in Sources */,
+				D92C57A41CC2E0820032DE59 /* XMPPStorageHintTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -305,6 +309,8 @@
 		63F55A571C60204300438CE2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};

--- a/Xcode/Testing-pod/XMPPFrameworkTests.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkTests.xcscheme
+++ b/Xcode/Testing-pod/XMPPFrameworkTests.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/Testing-pod/XMPPFrameworkTests/XMPPStorageHintTests.m
+++ b/Xcode/Testing-pod/XMPPFrameworkTests/XMPPStorageHintTests.m
@@ -29,11 +29,30 @@
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct results.
     XMPPMessage *message = [[XMPPMessage alloc] init];
-    XMPPMessageStorage storage = [message storageHint];
-    XCTAssertTrue(storage == XMPPMessageStorageUndefined);
-    [message setStorageHint:XMPPMessageStorageStore];
-    storage = [message storageHint];
-    XCTAssertTrue(storage == XMPPMessageStorageStore);
+    NSArray<NSValue*>* storageHints = [message storageHints];
+    XCTAssertNotNil(storageHints);
+    XCTAssertTrue(storageHints.count == 0);
+    
+    [message addStorageHint:XMPPMessageStorageNoCopy];
+    [message addStorageHint:XMPPMessageStorageNoPermanentStore];
+    [message addStorageHint:XMPPMessageStorageNoStore];
+    [message addStorageHint:XMPPMessageStorageStore];
+    // Should not be added
+    [message addStorageHint:XMPPMessageStorageUnknown];
+    storageHints = [message storageHints];
+    XCTAssertNotNil(storageHints);
+    XCTAssertTrue(storageHints.count == 4);
+    
+    BOOL result = [storageHints containsObject:@(XMPPMessageStorageNoCopy)];
+    XCTAssertTrue(result);
+    result = [storageHints containsObject:@(XMPPMessageStorageNoPermanentStore)];
+    XCTAssertTrue(result);
+    result = [storageHints containsObject:@(XMPPMessageStorageNoStore)];
+    XCTAssertTrue(result);
+    result = [storageHints containsObject:@(XMPPMessageStorageStore)];
+    XCTAssertTrue(result);
+    result = [storageHints containsObject:@(XMPPMessageStorageUnknown)];
+    XCTAssertFalse(result);
 }
 
 @end

--- a/Xcode/Testing-pod/XMPPFrameworkTests/XMPPStorageHintTests.m
+++ b/Xcode/Testing-pod/XMPPFrameworkTests/XMPPStorageHintTests.m
@@ -1,0 +1,39 @@
+//
+//  XMPPStorageHintTests.m
+//  XMPPFrameworkTests
+//
+//  Created by Chris Ballinger on 4/16/16.
+//
+//
+
+#import <XCTest/XCTest.h>
+@import XMPPFramework;
+
+@interface XMPPStorageHintTests : XCTestCase
+
+@end
+
+@implementation XMPPStorageHintTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testStorageElements {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    XMPPMessage *message = [[XMPPMessage alloc] init];
+    XMPPMessageStorage storage = [message storageHint];
+    XCTAssertTrue(storage == XMPPMessageStorageUndefined);
+    [message setStorageHint:XMPPMessageStorageStore];
+    storage = [message storageHint];
+    XCTAssertTrue(storage == XMPPMessageStorageStore);
+}
+
+@end


### PR DESCRIPTION
http://xmpp.org/extensions/xep-0334.html

> This specification aims to solve the following common problems, and allow a sender to hint to the recipient:
Whether to store a message (e.g. for archival or as an 'offline message').
Whether to copy a message to other resources.
Whether to store a message that would not have been stored under normal condition

