### PR TITLE
Fix avatar clearing vcard, no new fetches for 10 seconds

### DIFF
--- a/Extensions/XEP-0054/CoreDataStorage/XMPPvCardCoreDataStorage.m
+++ b/Extensions/XEP-0054/CoreDataStorage/XMPPvCardCoreDataStorage.m
@@ -128,7 +128,7 @@ static XMPPvCardCoreDataStorage *sharedInstance;
 		                                          inManagedObjectContext:[self managedObjectContext]];
 		
 		vCard.vCardTemp = nil;
-		vCard.lastUpdated = [NSDate date];
+		vCard.lastUpdated = [NSDate distantPast];
 	}];
 }
 


### PR DESCRIPTION
clearing local vCard -> cache is out of date -> lastUpdate = distantPast

lastUpdate is for local cache update and is considered when fetching a
new vCard.

If we set it to the date of *clearing* the cache new fetch will not be
made for at least 10 seconds (kXMPPvCardTempNetworkFetchTimeout).

So we should set it to the distant past, signaling that our local cache
is out of date. New fetches will go through (shouldFetchvCardTempForJID
returns YES)