### PR TITLE
Added vCard failure delegate and more tests

### DIFF
--- a/Extensions/XEP-0054/XMPPvCardTempModule.h
+++ b/Extensions/XEP-0054/XMPPvCardTempModule.h
@@ -65,6 +65,10 @@
         didReceivevCardTemp:(XMPPvCardTemp *)vCardTemp 
                      forJID:(XMPPJID *)jid;
 
+- (void)xmppvCardTempModule:(XMPPvCardTempModule *)vCardTempModule
+        failedToFetchvCardForJID:(XMPPJID *)jid
+                      error:(NSXMLElement*)error;
+
 - (void)xmppvCardTempModuleDidUpdateMyvCard:(XMPPvCardTempModule *)vCardTempModule;
 
 - (void)xmppvCardTempModule:(XMPPvCardTempModule *)vCardTempModule failedToUpdateMyvCard:(NSXMLElement *)error;

--- a/Xcode/Testing-pod/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-pod/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		C141EB1A1CF76CE900513A66 /* XMPPMockStream.m in Sources */ = {isa = PBXBuildFile; fileRef = C141EB191CF76CE900513A66 /* XMPPMockStream.m */; };
 		C1EA90581CFDC2F50019BC16 /* XMPPRoomLightTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1EA90571CFDC2F50019BC16 /* XMPPRoomLightTests.m */; };
 		D92C57A41CC2E0820032DE59 /* XMPPStorageHintTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D92C57A31CC2E0820032DE59 /* XMPPStorageHintTests.m */; };
+		D9BA12A31D1B55C70095CFE4 /* XMPPvCardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9BA12A21D1B55C70095CFE4 /* XMPPvCardTests.m */; };
 		E09D4B441CFCC4A000D37596 /* XMPPMUCLightTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E09D4B431CFCC4A000D37596 /* XMPPMUCLightTests.m */; };
 		E0AD9A5B1D09BF0B0067F707 /* XMPPRoomLightCoreDataStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0AD9A5A1D09BF0B0067F707 /* XMPPRoomLightCoreDataStorageTests.m */; };
 		E0ED56D11CF34D28004C726B /* XMPPHTTPFileUploadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0ED56D01CF34D28004C726B /* XMPPHTTPFileUploadTests.m */; };
@@ -34,6 +35,7 @@
 		C141EB191CF76CE900513A66 /* XMPPMockStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPMockStream.m; sourceTree = "<group>"; };
 		C1EA90571CFDC2F50019BC16 /* XMPPRoomLightTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPRoomLightTests.m; sourceTree = "<group>"; };
 		D92C57A31CC2E0820032DE59 /* XMPPStorageHintTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPStorageHintTests.m; sourceTree = "<group>"; };
+		D9BA12A21D1B55C70095CFE4 /* XMPPvCardTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPvCardTests.m; sourceTree = "<group>"; };
 		E09D4B431CFCC4A000D37596 /* XMPPMUCLightTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPMUCLightTests.m; sourceTree = "<group>"; };
 		E0AD9A5A1D09BF0B0067F707 /* XMPPRoomLightCoreDataStorageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPRoomLightCoreDataStorageTests.m; sourceTree = "<group>"; };
 		E0ED56D01CF34D28004C726B /* XMPPHTTPFileUploadTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPHTTPFileUploadTests.m; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 				E0ED56D51CF4D333004C726B /* XMPPMessageArchiveManagementTests.m */,
 				E09D4B431CFCC4A000D37596 /* XMPPMUCLightTests.m */,
 				C1EA90571CFDC2F50019BC16 /* XMPPRoomLightTests.m */,
+				D9BA12A21D1B55C70095CFE4 /* XMPPvCardTests.m */,
 				E0AD9A5A1D09BF0B0067F707 /* XMPPRoomLightCoreDataStorageTests.m */,
 				637AE2E81C6AC0D50051BF1F /* XMPPPushTests.swift */,
 				63F50D971C60208200CA0201 /* Info.plist */,
@@ -235,6 +238,7 @@
 				63F50DA01C6020A100CA0201 /* XMPPURITests.m in Sources */,
 				C1EA90581CFDC2F50019BC16 /* XMPPRoomLightTests.m in Sources */,
 				D92C57A41CC2E0820032DE59 /* XMPPStorageHintTests.m in Sources */,
+				D9BA12A31D1B55C70095CFE4 /* XMPPvCardTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xcode/Testing-pod/XMPPFrameworkTests.xcworkspace/xcshareddata/XMPPFrameworkTests.xcscmblueprint
+++ b/Xcode/Testing-pod/XMPPFrameworkTests.xcworkspace/xcshareddata/XMPPFrameworkTests.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D" : 0,
+    "65A79C2919A5538250064F3C245A290D7BFC656E" : 0
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "3D2D91C5-9595-4027-8C01-22647584F8B3",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D" : "XMPPFramework\/",
+    "65A79C2919A5538250064F3C245A290D7BFC656E" : ".."
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "XMPPFrameworkTests",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "Xcode\/Testing-pod\/XMPPFrameworkTests.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:ChatSecure\/ChatSecure-iOS.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "65A79C2919A5538250064F3C245A290D7BFC656E"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:robbiehanson\/XMPPFramework.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "B775552D1BBEEADC6A0BBB2FD048B6AA26CB309D"
+    }
+  ]
+}

--- a/Xcode/Testing-pod/XMPPFrameworkTests/XMPPMockStream.h
+++ b/Xcode/Testing-pod/XMPPFrameworkTests/XMPPMockStream.h
@@ -14,6 +14,5 @@
 - (void)fakeMessageResponse:(XMPPMessage *) message;
 
 @property (nonatomic, copy) void (^elementReceived)(NSXMLElement *element);
-@property (nonatomic, strong) id delegate;
 
 @end

--- a/Xcode/Testing-pod/XMPPFrameworkTests/XMPPMockStream.m
+++ b/Xcode/Testing-pod/XMPPFrameworkTests/XMPPMockStream.m
@@ -7,23 +7,31 @@
 //
 
 #import "XMPPMockStream.h"
+#import "XMPPInternal.h"
 
 @implementation XMPPMockStream
 
+- (id) init {
+    if (self = [super init]) {
+        [super setValue:@(STATE_XMPP_CONNECTED) forKey:@"state"];
+    }
+    return self;
+}
+
+- (BOOL) isAuthenticated {
+    return YES;
+}
+
 - (void)fakeMessageResponse:(XMPPMessage *) message {
-	[((id<XMPPStreamDelegate>)self.delegate) xmppStream:self didReceiveMessage:message];
+    [self injectElement:message];
 }
 
 - (void)fakeIQResponse:(XMPPIQ *) iq {
-	[((id<XMPPStreamDelegate>)self.delegate) xmppStream:self didReceiveIQ:iq];
-}
-
-- (void)addDelegate:(id)delegate delegateQueue:(dispatch_queue_t)delegateQueue{
-	[super addDelegate:delegate delegateQueue:delegateQueue];
-	self.delegate = delegate;
+    [self injectElement:iq];
 }
 
 - (void)sendElement:(NSXMLElement *)element {
+    [super sendElement:element];
 	if(self.elementReceived) {
 		self.elementReceived(element);
 	}

--- a/Xcode/Testing-pod/XMPPFrameworkTests/XMPPvCardTests.m
+++ b/Xcode/Testing-pod/XMPPFrameworkTests/XMPPvCardTests.m
@@ -1,0 +1,89 @@
+//
+//  XMPPvCardTests.m
+//  XMPPFrameworkTests
+//
+//  Created by Chris Ballinger on 6/22/16.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import "XMPPMockStream.h"
+#import "XMPPvCardTempModule.h"
+#import "XMPPvCardCoreDataStorage.h"
+
+@interface XMPPvCardTests : XCTestCase
+@property (nonatomic, strong) XCTestExpectation *expectation;
+@end
+
+@implementation XMPPvCardTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testVcardFetchFailure {
+    self.expectation = [self expectationWithDescription:@"vCard Fetch Failure"];
+    
+    NSString *jidString = @"test@example.com/house";
+    XMPPJID *myJID = [XMPPJID jidWithString:jidString];
+    XMPPMockStream *stream = [[XMPPMockStream alloc] init];
+    stream.myJID = myJID;
+    XMPPvCardCoreDataStorage *storage = [[XMPPvCardCoreDataStorage alloc] initWithInMemoryStore];
+    XMPPvCardTempModule *vcardModule = [[XMPPvCardTempModule alloc] initWithvCardStorage:storage];
+    [vcardModule addDelegate:self delegateQueue:dispatch_get_main_queue()];
+    [vcardModule activate:stream];
+    
+    __weak typeof(XMPPMockStream) *weakStreamTest = stream;
+    stream.elementReceived = ^void(NSXMLElement *element) {
+        NSLog(@"received element: %@", element);
+        XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+        NSString *eid = [iq elementID];
+        XMPPIQ *response = [self fakeFetchErrorWithElementId:eid jidString:jidString];
+        NSLog(@"sending response: %@", response);
+        [weakStreamTest fakeIQResponse:response];
+    };
+    
+    [vcardModule fetchvCardTempForJID:myJID];
+    
+    [self waitForExpectationsWithTimeout:60 handler:^(NSError * _Nullable error) {
+        if(error){
+            XCTFail(@"Expectation Failed with error: %@", error);
+        }
+    }];
+}
+
+- (XMPPIQ*) fakeFetchErrorWithElementId:(NSString*)elementId jidString:(NSString*)jidString {
+    NSString * errorString =
+    [NSString stringWithFormat:@"<iq id='%@'\
+    to='%@'\
+    type='error'>\
+    <vCard xmlns='vcard-temp'/>\
+    <error type='cancel'>\
+    <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
+    </error>\
+     </iq>", elementId, jidString];
+    NSError *error = nil;
+    NSXMLElement *element = [[NSXMLElement alloc] initWithXMLString:errorString error:&error];
+    if (error) {
+        XCTFail(@"Error: %@", error);
+    }
+    XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+    return iq;
+}
+
+#pragma mark XMPPvCardTempModuleDelegate methods
+
+- (void)xmppvCardTempModule:(XMPPvCardTempModule *)vCardTempModule
+   failedToFetchvCardForJID:(XMPPJID *)jid
+                      error:(NSXMLElement*)error {
+    NSLog(@"failedToFetchvCardForJID %@ %@", jid, error);
+    [self.expectation fulfill];
+}
+
+@end

--- a/Xcode/Testing-pod/XMPPFrameworkTests/XMPPvCardTests.m
+++ b/Xcode/Testing-pod/XMPPFrameworkTests/XMPPvCardTests.m
@@ -12,44 +12,51 @@
 #import "XMPPvCardCoreDataStorage.h"
 
 @interface XMPPvCardTests : XCTestCase
-@property (nonatomic, strong) XCTestExpectation *expectation;
+@property (nonatomic, strong) XCTestExpectation *failureExpectation;
+@property (nonatomic, strong) XCTestExpectation *successExpectation;
+
+@property (nonatomic, strong) XMPPMockStream *stream;
+@property (nonatomic, strong) XMPPvCardTempModule *vcardModule;
 @end
 
 @implementation XMPPvCardTests
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    NSString *jidString = @"test@example.com/house";
+    XMPPJID *myJID = [XMPPJID jidWithString:jidString];
+    self.stream = [[XMPPMockStream alloc] init];
+    self.stream.myJID = myJID;
+    XMPPvCardCoreDataStorage *storage = [[XMPPvCardCoreDataStorage alloc] initWithInMemoryStore];
+    self.vcardModule = [[XMPPvCardTempModule alloc] initWithvCardStorage:storage];
+    [self.vcardModule addDelegate:self delegateQueue:dispatch_get_main_queue()];
+    [self.vcardModule activate:self.stream];
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [self.vcardModule removeDelegate:self];
+    [self.vcardModule deactivate];
+    self.vcardModule = nil;
+    self.stream = nil;
     [super tearDown];
 }
 
-- (void)testVcardFetchFailure {
-    self.expectation = [self expectationWithDescription:@"vCard Fetch Failure"];
+- (void)testVcardSelfItemNotFound {
+    self.failureExpectation = [self expectationWithDescription:@"testVcardItemNotFound"];
     
-    NSString *jidString = @"test@example.com/house";
-    XMPPJID *myJID = [XMPPJID jidWithString:jidString];
-    XMPPMockStream *stream = [[XMPPMockStream alloc] init];
-    stream.myJID = myJID;
-    XMPPvCardCoreDataStorage *storage = [[XMPPvCardCoreDataStorage alloc] initWithInMemoryStore];
-    XMPPvCardTempModule *vcardModule = [[XMPPvCardTempModule alloc] initWithvCardStorage:storage];
-    [vcardModule addDelegate:self delegateQueue:dispatch_get_main_queue()];
-    [vcardModule activate:stream];
-    
-    __weak typeof(XMPPMockStream) *weakStreamTest = stream;
-    stream.elementReceived = ^void(NSXMLElement *element) {
+    __weak typeof(XMPPMockStream) *weakStreamTest = self.stream;
+    __weak typeof(self) weakSelf = self;
+
+    self.stream.elementReceived = ^void(NSXMLElement *element) {
         NSLog(@"received element: %@", element);
         XMPPIQ *iq = [XMPPIQ iqFromElement:element];
         NSString *eid = [iq elementID];
-        XMPPIQ *response = [self fakeFetchErrorWithElementId:eid jidString:jidString];
+        XMPPIQ *response = [weakSelf fakeItemSelfNotFoundWithElementId:eid toJID:weakStreamTest.myJID.bare];
         NSLog(@"sending response: %@", response);
         [weakStreamTest fakeIQResponse:response];
     };
     
-    [vcardModule fetchvCardTempForJID:myJID];
+    [self.vcardModule fetchvCardTempForJID:self.stream.myJID];
     
     [self waitForExpectationsWithTimeout:60 handler:^(NSError * _Nullable error) {
         if(error){
@@ -58,16 +65,183 @@
     }];
 }
 
-- (XMPPIQ*) fakeFetchErrorWithElementId:(NSString*)elementId jidString:(NSString*)jidString {
+- (void)testVcardSelfEmpty {
+    self.failureExpectation = [self expectationWithDescription:@"testVcardEmpty"];
+    
+    __weak typeof(XMPPMockStream) *weakStreamTest = self.stream;
+    __weak typeof(self) weakSelf = self;
+    
+    self.stream.elementReceived = ^void(NSXMLElement *element) {
+        NSLog(@"received element: %@", element);
+        XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+        NSString *eid = [iq elementID];
+        XMPPIQ *response = [weakSelf fakeEmptySelfvCardWithElementId:eid toJID:weakStreamTest.myJID.bare];
+        NSLog(@"sending response: %@", response);
+        [weakStreamTest fakeIQResponse:response];
+    };
+    
+    [self.vcardModule fetchvCardTempForJID:self.stream.myJID];
+    
+    [self waitForExpectationsWithTimeout:60 handler:^(NSError * _Nullable error) {
+        if(error){
+            XCTFail(@"Expectation Failed with error: %@", error);
+        }
+    }];
+}
+
+- (void) testVcardSelfSuccess {
+    self.successExpectation = [self expectationWithDescription:@"testVcardSelfSuccess"];
+    
+    __weak typeof(XMPPMockStream) *weakStreamTest = self.stream;
+    __weak typeof(self) weakSelf = self;
+    
+    self.stream.elementReceived = ^void(NSXMLElement *element) {
+        NSLog(@"received element: %@", element);
+        XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+        NSString *eid = [iq elementID];
+        XMPPIQ *response = [weakSelf fakeSelfvCardWithElementId:eid toJID:weakStreamTest.myJID.bare];
+        NSLog(@"sending response: %@", response);
+        [weakStreamTest fakeIQResponse:response];
+    };
+    
+    [self.vcardModule fetchvCardTempForJID:self.stream.myJID];
+    
+    [self waitForExpectationsWithTimeout:60 handler:^(NSError * _Nullable error) {
+        if(error){
+            XCTFail(@"Expectation Failed with error: %@", error);
+        }
+    }];
+}
+
+- (void) testVcardContactSuccess {
+    self.successExpectation = [self expectationWithDescription:@"testVcardContactSuccess"];
+    
+    __weak typeof(XMPPMockStream) *weakStreamTest = self.stream;
+    __weak typeof(self) weakSelf = self;
+    
+    XMPPJID *contact = [XMPPJID jidWithString:@"bob@com.com/res"];
+    
+    self.stream.elementReceived = ^void(NSXMLElement *element) {
+        NSLog(@"received element: %@", element);
+        XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+        NSString *eid = [iq elementID];
+        XMPPIQ *response = [weakSelf fakeContactvCardWithElementId:eid toJID:weakStreamTest.myJID.bare fromJID:contact.bare];
+        NSLog(@"sending response: %@", response);
+        [weakStreamTest fakeIQResponse:response];
+    };
+    
+    [self.vcardModule fetchvCardTempForJID:contact];
+    
+    [self waitForExpectationsWithTimeout:60 handler:^(NSError * _Nullable error) {
+        if(error){
+            XCTFail(@"Expectation Failed with error: %@", error);
+        }
+    }];
+}
+
+- (void) testVcardContactFailure {
+    self.failureExpectation = [self expectationWithDescription:@"testVcardContactFailure"];
+    
+    __weak typeof(XMPPMockStream) *weakStreamTest = self.stream;
+    __weak typeof(self) weakSelf = self;
+    
+    XMPPJID *contact = [XMPPJID jidWithString:@"bob@com.com/res"];
+    
+    self.stream.elementReceived = ^void(NSXMLElement *element) {
+        NSLog(@"received element: %@", element);
+        XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+        NSString *eid = [iq elementID];
+        XMPPIQ *response = [weakSelf fakeContactFailurevCardWithElementId:eid toJID:weakStreamTest.myJID.bare];
+        NSLog(@"sending response: %@", response);
+        [weakStreamTest fakeIQResponse:response];
+    };
+    
+    [self.vcardModule fetchvCardTempForJID:contact];
+    
+    [self waitForExpectationsWithTimeout:60 handler:^(NSError * _Nullable error) {
+        if(error){
+            XCTFail(@"Expectation Failed with error: %@", error);
+        }
+    }];
+}
+
+#pragma mark IQ Generators
+
+- (XMPPIQ*) fakeItemSelfNotFoundWithElementId:(NSString*)elementId toJID:(NSString*)toJID {
+    NSString * errorString =
+    [NSString stringWithFormat:@"<iq xmlns=\"jabber:client\" id=\"%@\" type=\"error\" to=\"%@\"><error type=\"cancel\"><item-not-found xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/></error></iq>", elementId, toJID];
+    NSError *error = nil;
+    NSXMLElement *element = [[NSXMLElement alloc] initWithXMLString:errorString error:&error];
+    if (error) {
+        XCTFail(@"Error: %@", error);
+    }
+    XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+    return iq;
+}
+
+- (XMPPIQ*) fakeEmptySelfvCardWithElementId:(NSString*)elementId toJID:(NSString*)toJID {
     NSString * errorString =
     [NSString stringWithFormat:@"<iq id='%@'\
-    to='%@'\
-    type='error'>\
-    <vCard xmlns='vcard-temp'/>\
-    <error type='cancel'>\
-    <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
-    </error>\
-     </iq>", elementId, jidString];
+     to='%@'\
+     type='result'>\
+     <vCard xmlns='vcard-temp'/>\
+     </iq>", elementId, toJID];
+    NSError *error = nil;
+    NSXMLElement *element = [[NSXMLElement alloc] initWithXMLString:errorString error:&error];
+    if (error) {
+        XCTFail(@"Error: %@", error);
+    }
+    XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+    return iq;
+}
+
+- (XMPPIQ*) fakeSelfvCardWithElementId:(NSString*)elementId toJID:(NSString*)toJID {
+    NSString * errorString =
+    [NSString stringWithFormat:@"<iq id='%@'\
+     to='%@'\
+     type='result'>\
+     <vCard xmlns='vcard-temp'>\
+     <NICKNAME>stpeter</NICKNAME>\
+     </vCard>\
+     </iq>", elementId, toJID];
+    NSError *error = nil;
+    NSXMLElement *element = [[NSXMLElement alloc] initWithXMLString:errorString error:&error];
+    if (error) {
+        XCTFail(@"Error: %@", error);
+    }
+    XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+    return iq;
+}
+
+- (XMPPIQ*) fakeContactvCardWithElementId:(NSString*)elementId toJID:(NSString*)toJID fromJID:(NSString*)fromJID {
+    NSString * errorString =
+    [NSString stringWithFormat:@"<iq from='%@' \
+     to='%@' \
+     type='result'\
+     id='%@'>\
+     <vCard xmlns='vcard-temp'>\
+     <FN>JeremieMiller</FN>\
+     </vCard>\
+     </iq>", fromJID, toJID, elementId];
+    NSError *error = nil;
+    NSXMLElement *element = [[NSXMLElement alloc] initWithXMLString:errorString error:&error];
+    if (error) {
+        XCTFail(@"Error: %@", error);
+    }
+    XMPPIQ *iq = [XMPPIQ iqFromElement:element];
+    return iq;
+}
+
+- (XMPPIQ*) fakeContactFailurevCardWithElementId:(NSString*)elementId toJID:(NSString*)toJID {
+    NSString * errorString =
+    [NSString stringWithFormat:@"<iq id='%@'\
+     to='%@'\
+     type='error'>\
+     <vCard xmlns='vcard-temp'/>\
+     <error type='cancel'>\
+     <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
+     </error>\
+     </iq>", elementId, toJID];
     NSError *error = nil;
     NSXMLElement *element = [[NSXMLElement alloc] initWithXMLString:errorString error:&error];
     if (error) {
@@ -83,7 +257,19 @@
    failedToFetchvCardForJID:(XMPPJID *)jid
                       error:(NSXMLElement*)error {
     NSLog(@"failedToFetchvCardForJID %@ %@", jid, error);
-    [self.expectation fulfill];
+    [self.failureExpectation fulfill];
+    
+    if (self.successExpectation) {
+        XCTFail(@"Expecting success and got failure");
+        [self.successExpectation fulfill];
+    }
+}
+
+- (void)xmppvCardTempModule:(XMPPvCardTempModule *)vCardTempModule
+        didReceivevCardTemp:(XMPPvCardTemp *)vCardTemp
+                     forJID:(XMPPJID *)jid {
+    NSLog(@"didReceivevCardTemp %@ %@", vCardTemp, jid);
+    [self.successExpectation fulfill];
 }
 
 @end


### PR DESCRIPTION
I had a need for a delegate callback for failure to fetch vCard. In the process I added test coverage to XMPPvCardTempModule using the new XMPPMockStream class. I also modified the XMPPMockStream class to act more like a regular stream to better support multicast delegate / modules.

When testing against Prosody I noticed they don't conform to the spec, so.. yeah.