### PR TITLE
wrong name in the class value of the entity

### DIFF
--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLight.xcdatamodel/contents
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLight.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Xcode 7.0">
-    <entity name="XMPPRoomLightMessageCoreDataStorageObject" representedClassName="XMPPRoomMessageCoreDataStorageObject" syncable="YES">
+    <entity name="XMPPRoomLightMessageCoreDataStorageObject" representedClassName="XMPPRoomLightMessageCoreDataStorageObject" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="fromMe" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="jid" optional="YES" transient="YES" syncable="YES"/>

--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
@@ -25,16 +25,13 @@
 
 - (void)handleIncomingMessage:(XMPPMessage *)message room:(XMPPRoomLight *)room{
 	XMPPStream *xmppStream = room.xmppStream;
-
-	XMPPJID *myRoomJID = [XMPPJID jidWithUser:message.from.user
-									   domain:message.from.domain
-									 resource:xmppStream.myJID.full];
-
-	XMPPJID *messageJID = [message from];
-
+	
+	XMPPJID *roomFromUser = [XMPPJID jidWithString:[message from].resource];
+	XMPPJID *myUser = [room.xmppStream myJID];
+	
 	// Ignore - if message is mine and it was not delayed then ignore
 	// becuase we handled it in handleOutgoingMessage:room:
-	if ([myRoomJID isEqualToJID:messageJID] && ![message wasDelayed]){
+	if([roomFromUser isEqualToJID:myUser options:XMPPJIDCompareBare] && ![message wasDelayed]) {
 		return;
 	}
 

--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
@@ -173,7 +173,7 @@
 }
 
 - (void)didInsertMessage:(XMPPRoomLightMessageCoreDataStorageObject *)message{
-	// Override me if you're extending the XMPPRoomMessageCoreDataStorageObject class to add additional properties.
+	// Override me if you're extending the XMPPRoomLightMessageCoreDataStorageObject class to add additional properties.
 	// You can update your additional properties here.
 	//
 	// At this point the standard properties have already been set.


### PR DESCRIPTION
When getting a message from a NSFetchedResultsController and casting it to `XMPPRoomLightMessageCoreDataStorageObject` it failed because a wrong class was set in the CoreData entity. This PR fixes that issue.
```
let message = self.fetchedResultsController.objectAtIndexPath(indexPath) as! XMPPRoomLightMessageCoreDataStorageObject
```
