### PR TITLE
Andres.bugs xmpp room light

### DIFF
--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLight.xcdatamodel/contents
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLight.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Xcode 7.0">
-    <entity name="XMPPRoomLightMessageCoreDataStorageObject" representedClassName="XMPPRoomMessageCoreDataStorageObject" syncable="YES">
+    <entity name="XMPPRoomLightMessageCoreDataStorageObject" representedClassName="XMPPRoomLightMessageCoreDataStorageObject" syncable="YES">
         <attribute name="body" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="fromMe" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="jid" optional="YES" transient="YES" syncable="YES"/>

--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
@@ -25,16 +25,13 @@
 
 - (void)handleIncomingMessage:(XMPPMessage *)message room:(XMPPRoomLight *)room{
 	XMPPStream *xmppStream = room.xmppStream;
-
-	XMPPJID *myRoomJID = [XMPPJID jidWithUser:message.from.user
-									   domain:message.from.domain
-									 resource:xmppStream.myJID.full];
-
-	XMPPJID *messageJID = [message from];
-
+	
+	XMPPJID *roomFromUser = [XMPPJID jidWithString:[message from].resource];
+	XMPPJID *myUser = [room.xmppStream myJID];
+	
 	// Ignore - if message is mine and it was not delayed then ignore
 	// becuase we handled it in handleOutgoingMessage:room:
-	if ([myRoomJID isEqualToJID:messageJID] && ![message wasDelayed]){
+	if([roomFromUser isEqualToJID:myUser options:XMPPJIDCompareBare] && ![message wasDelayed]) {
 		return;
 	}
 

--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
@@ -173,7 +173,7 @@
 }
 
 - (void)didInsertMessage:(XMPPRoomLightMessageCoreDataStorageObject *)message{
-	// Override me if you're extending the XMPPRoomMessageCoreDataStorageObject class to add additional properties.
+	// Override me if you're extending the XMPPRoomLightMessageCoreDataStorageObject class to add additional properties.
 	// You can update your additional properties here.
 	//
 	// At this point the standard properties have already been set.

--- a/Extensions/XMPPMUCLight/XMPPRoomLight.h
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.h
@@ -38,7 +38,7 @@
 - (void)changeAffiliations:(nonnull NSArray<NSXMLElement *> *)members;
 - (void)getConfiguration;
 - (void)setConfiguration:(nonnull NSArray<NSXMLElement *> *)configs;
-
+- (void)flushVersion;
 @end
 
 @protocol XMPPRoomLightStorage <NSObject>

--- a/Extensions/XMPPMUCLight/XMPPRoomLight.m
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.m
@@ -16,7 +16,8 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 @interface XMPPRoomLight() {
 	NSString *roomname;
 	NSString *subject;
-	NSString *version;
+	NSString *configVersion;
+	NSString *memberListVersion;
 }
 @end
 
@@ -40,6 +41,8 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 		_domain = aRoomJID.domain;
 		_roomJID = aRoomJID;
 		roomname = aRoomname;
+		configVersion = @"";
+		memberListVersion = @"";
 	}
 	return self;
 
@@ -84,9 +87,15 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 	}
 }
 
-- (nonnull NSString *)version {
+- (nonnull NSString *)configVersion {
 	@synchronized(subject) {
-		return [version copy];
+		return [configVersion copy];
+	}
+}
+
+- (nonnull NSString *)memberListVersion {
+	@synchronized(subject) {
+		return [memberListVersion copy];
 	}
 }
 
@@ -122,15 +131,31 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 		dispatch_async(moduleQueue, block);
 }
 
-- (void)setVersion:(NSString *)aVersion{
+- (void)setMemberListVersion:(NSString *)aVersion{
 	dispatch_block_t block = ^{ @autoreleasepool {
-		version = aVersion;
+		memberListVersion = aVersion;
 	}};
 
 	if (dispatch_get_specific(moduleQueueTag))
 		block();
 	else
 		dispatch_async(moduleQueue, block);
+}
+
+- (void)setConfigVersion:(NSString *)aVersion{
+	dispatch_block_t block = ^{ @autoreleasepool {
+		configVersion = aVersion;
+	}};
+	
+	if (dispatch_get_specific(moduleQueueTag))
+		block();
+	else
+		dispatch_async(moduleQueue, block);
+}
+
+- (void)flushVersion{
+	[self setConfigVersion:@""];
+	[self setMemberListVersion:@""];
 }
 
 - (void)createRoomLightWithMembersJID:(nullable NSArray<XMPPJID *> *) members{
@@ -314,7 +339,8 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 		NSString *iqID = [XMPPStream generateUUID];
 		XMPPIQ *iq = [XMPPIQ iqWithType:@"get" to:_roomJID elementID:iqID];
 		NSXMLElement *query = [NSXMLElement elementWithName:@"query" xmlns:XMPPRoomLightAffiliations];
-		[query addChild:[NSXMLElement elementWithName:@"version" stringValue:self.version]];
+
+		[query addChild:[NSXMLElement elementWithName:@"version" stringValue:self.memberListVersion]];
 		[iq addChild:query];
 		
 		[responseTracker addID:iqID
@@ -335,8 +361,15 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 	if ([[iq type] isEqualToString:@"result"]){
 		NSXMLElement *query = [iq elementForName:@"query"
 										   xmlns:XMPPRoomLightAffiliations];
-		NSArray *items = [query elementsForName:@"user"];
+
+		NSXMLElement *inVersion = [query elementForName:@"version"];
+		if(inVersion){
+			[self setMemberListVersion:inVersion.stringValue];
+		}
 		
+		NSArray *items = [query elementsForName:@"user"];
+		if (!items) { items = @[]; }
+
 		[multicastDelegate xmppRoomLight:self didFetchMembersList:items];
 	}else{
 		[multicastDelegate xmppRoomLight:self didFailToFetchMembersList:iq];
@@ -475,7 +508,8 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 		NSString *iqID = [XMPPStream generateUUID];
 		XMPPIQ *iq = [XMPPIQ iqWithType:@"get" to:_roomJID elementID:iqID];
 		NSXMLElement *query = [NSXMLElement elementWithName:@"query" xmlns:XMPPRoomLightConfiguration];
-		[query addChild:[NSXMLElement elementWithName:@"version" stringValue:self.version]];
+
+		[query addChild:[NSXMLElement elementWithName:@"version" stringValue:self.configVersion]];
 		[iq addChild:query];
 
 		[responseTracker addID:iqID
@@ -494,6 +528,13 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 
 - (void)handleGetConfiguration:(XMPPIQ *)iq withInfo:(id <XMPPTrackingInfo>)info{
 	if ([[iq type] isEqualToString:@"result"]) {
+
+		NSXMLElement *query = [[iq elementsForLocalName:@"query" URI:XMPPRoomLightConfiguration] firstObject];
+		NSXMLElement *inVersion = [query elementForName:@"version"];
+		if(inVersion){
+			[self setConfigVersion:inVersion.stringValue];
+		}
+
 		NSArray *configElements = [[iq elementsForLocalName:@"query" URI:XMPPRoomLightConfiguration] firstObject].children;
 		[self handleConfigElements:configElements];
 
@@ -547,13 +588,6 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 
 - (BOOL)xmppStream:(XMPPStream *)sender didReceiveIQ:(XMPPIQ *)iq{
 	NSString *type = [iq type];
-    
-	NSXMLElement *query = [[iq elementsForLocalName:@"query" URI:XMPPRoomLightConfiguration] firstObject];
-	NSXMLElement *inVersion = [query elementForName:@"version"];
-	if(inVersion){
-		[self setVersion:inVersion.stringValue];
-	}
-
 	if ([type isEqualToString:@"result"] || [type isEqualToString:@"error"]){
 		return [responseTracker invokeForID:[iq elementID] withObject:iq];
 	}

--- a/Xcode/Testing-Shared/XMPPRoomLightTests.m
+++ b/Xcode/Testing-Shared/XMPPRoomLightTests.m
@@ -11,6 +11,11 @@
 #import "XMPPRoomLight.h"
 #import "XMPPJID.h"
 
+@interface XMPPRoomLight()
+- (nonnull NSString *)memberListVersion;
+- (nonnull NSString *)configVersion;
+@end
+
 @interface XMPPRoomLightTests : XCTestCase <XMPPRoomLightDelegate>
 
 @property (nonatomic, strong) XCTestExpectation *delegateResponseExpectation;
@@ -19,6 +24,13 @@
 @end
 
 @implementation XMPPRoomLightTests
+
+- (void)testInitVersionsShouldBeEmpty {
+	XMPPJID *jid = [XMPPJID jidWithUser:@"user" domain:@"domain.com" resource:@"resource"];
+	XMPPRoomLight *roomLight = [[XMPPRoomLight alloc] initWithJID:jid roomname:@"room"];
+	XCTAssertEqualObjects(roomLight.memberListVersion, @"");
+	XCTAssertEqualObjects(roomLight.configVersion, @"");
+}
 
 - (void)testInitWithJIDAndRoomname {
 	XMPPJID *jid = [XMPPJID jidWithUser:@"user" domain:@"domain.com" resource:@"resource"];
@@ -292,6 +304,7 @@
 	XCTAssertEqualObjects([user3 attributeForName:@"affiliation"].stringValue, @"member");
 	XCTAssertEqualObjects(user3.stringValue, @"user3@shakespeare.lit");
 
+	XCTAssertEqualObjects(sender.memberListVersion, @"123456");
 	[self.delegateResponseExpectation fulfill];
 }
 
@@ -617,6 +630,7 @@
 }
 
 - (void)xmppRoomLight:(XMPPRoomLight *)sender didGetConfiguration:(XMPPIQ *)iqResult{
+	XCTAssertEqualObjects(sender.configVersion, @"123456");
 	[self.delegateResponseExpectation fulfill];
 }
 
@@ -769,6 +783,7 @@
 	NSMutableString *s = [NSMutableString string];
 	[s appendString:@"<iq xmlns='jabber:client' from='testtesttest@muclight.erlang-solutions.com' to='ramabit@erlang-solutions.com/Andress-MacBook-Air' id='config0' type='result'>"];
 	[s appendString:@"	<query xmlns='urn:xmpp:muclight:0#configuration'>"];
+	[s appendString:@"		<version>123456</version>"];
 	[s appendString:@"		<roomname>Roomname</roomname>"];
 	[s appendString:@"		<subject>Subject</subject>"];
 	[s appendString:@"	</query>"];


### PR DESCRIPTION
I've been using XMPPRoom heavily lately and I found a couple of simple bugs this fixes them:
- Wrong name in the class value of the entity in XMPPRoomLight.xcdatamodel
- When sending a message to a MUC light room that same message was stored when received
- Added two different values for the Version to XMPPRoom one to use when fetching members and one to use when fetching the config, and a method to flush the version. If the same was used I couldn't get the list of members after getting the configuration.
- When fetching the list of members if no members where in the IQ received it was returning an nil and sending that nil to a delegate method that accepted nonnulls.
 