### PR TITLE
Fix crash in XMPPCapabilities dealloc

### DIFF
--- a/Extensions/XEP-0115/XMPPCapabilities.h
+++ b/Extensions/XEP-0115/XMPPCapabilities.h
@@ -4,6 +4,7 @@
 #define _XMPP_CAPABILITIES_H
 
 @protocol XMPPCapabilitiesStorage;
+@class GCDTimerWrapper;
 
 /**
  * This class provides support for capabilities discovery.
@@ -28,7 +29,7 @@
 	
 	NSMutableSet *discoRequestJidSet;
 	NSMutableDictionary *discoRequestHashDict;
-	NSMutableDictionary *discoTimerJidDict;
+	NSMutableDictionary<XMPPJID*,GCDTimerWrapper*> *discoTimerJidDict;
 	
 	BOOL autoFetchHashedCapabilities;
 	BOOL autoFetchNonHashedCapabilities;

--- a/Extensions/XEP-0115/XMPPCapabilities.m
+++ b/Extensions/XEP-0115/XMPPCapabilities.m
@@ -152,12 +152,10 @@
 }
 
 - (void)dealloc
-{	
-	for (GCDTimerWrapper *timerWrapper in discoTimerJidDict)
-	{
-		[timerWrapper cancel];
-	}
-	
+{
+    [discoTimerJidDict enumerateKeysAndObjectsUsingBlock:^(XMPPJID * _Nonnull key, GCDTimerWrapper * _Nonnull obj, BOOL * _Nonnull stop) {
+        [obj cancel];
+    }];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Been seeing a few of these crashes in production. In theory this will fix it..

Application Specific Information:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[XMPPJID cancel]: unrecognized selector sent to instance 0x149423730'

Last Exception Backtrace:
0   CoreFoundation                       0x0000000180f7adb0 __exceptionPreprocess + 124
1   libobjc.A.dylib                      0x00000001805dff80 objc_exception_throw + 52
2   CoreFoundation                       0x0000000180f81c4c -[NSObject(NSObject) doesNotRecognizeSelector:] + 208
3   CoreFoundation                       0x0000000180f7ebec ___forwarding___ + 868
4   CoreFoundation                       0x0000000180e7cc5c _CF_forwarding_prep_0 + 88
5   XMPPFramework                        0x000000010121f8f8 -[XMPPCapabilities dealloc] (XMPPCapabilities.m:158)
6   XMPPFramework                        0x0000000101224aa4 __destroy_helper_block_.330 (XMPPCapabilities.m:0)
7   libsystem_blocks.dylib               0x0000000180a218e8 _Block_release + 152
8   libdispatch.dylib                    0x00000001809daca0 _dispatch_source_cancel_callout + 64
9   libdispatch.dylib                    0x00000001809c7944 _dispatch_source_invoke + 760
10  libdispatch.dylib                    0x00000001809d1694 _dispatch_queue_drain + 1328
11  libdispatch.dylib                    0x00000001809c8f80 _dispatch_queue_invoke + 460
12  libdispatch.dylib                    0x00000001809d3390 _dispatch_root_queue_drain + 724
13  libdispatch.dylib                    0x00000001809d30b0 _dispatch_worker_thread3 + 108
14  libsystem_pthread.dylib              0x0000000180bdd470 _pthread_wqthread + 1088
15  libsystem_pthread.dylib              0x0000000180bdd020 start_wqthread + 0