### PR TITLE
use CocoaLumberjack 3.0 or newer

### DIFF
--- a/XMPPFramework.podspec
+++ b/XMPPFramework.podspec
@@ -47,7 +47,7 @@ s.source = { :git => 'https://github.com/robbiehanson/XMPPFramework.git', :branc
       'HEADER_SEARCH_PATHS' => '$(inherited) $(SDKROOT)/usr/include/libxml2 $(SDKROOT)/usr/include/libresolv',
       'ENABLE_BITCODE' => 'NO'
     }
-    core.dependency 'CocoaLumberjack', '~> 2.0'
+    core.dependency 'CocoaLumberjack', '~> 3.0'
     core.dependency 'CocoaAsyncSocket', '~> 7.5.0'
     core.dependency 'KissXML', '~> 5.1.2'
   end


### PR DESCRIPTION
With the current setup having both XMPPFramework and CocoaLumberjack 3.0 installed via CocoaPods conflicts on CocoaLumberjack 2.x dependency. Since CocoaLumberjack 3.0 differences are Swift related shouldn't affect the project in any way.