### PR TITLE
delegate subject change to multicastDelegate

### DIFF
--- a/Extensions/XEP-0045/XMPPRoom.h
+++ b/Extensions/XEP-0045/XMPPRoom.h
@@ -310,5 +310,6 @@ static NSString *const XMPPMUCOwnerNamespace = @"http://jabber.org/protocol/muc#
 
 - (void)xmppRoom:(XMPPRoom *)sender didEditPrivileges:(XMPPIQ *)iqResult;
 - (void)xmppRoom:(XMPPRoom *)sender didNotEditPrivileges:(XMPPIQ *)iqError;
+- (void)xmppRoomDidChangeSubject:(XMPPRoom *)sender;
 
 @end

--- a/Extensions/XEP-0045/XMPPRoom.m
+++ b/Extensions/XEP-0045/XMPPRoom.m
@@ -1090,6 +1090,7 @@ enum XMPPRoomState
     else if ([message isGroupChatMessageWithSubject])
     {
         roomSubject = [message subject];
+        [multicastDelegate xmppRoomDidChangeSubject:self];
     }
 	else
 	{


### PR DESCRIPTION
After a `XMPPRoom` did receive subject change, the event is delegated through `multiCastDelegate` so a `XMPPRoomDelegate` can be notified about change and perform actions (e.g. for UI changes).