### PR TITLE
Prefer IPv6 over IPv4 by default, partially fixes #718

### DIFF
--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -271,6 +271,26 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
 
 #endif
 
+/**
+ * By default, IPv6 is now preferred over IPv4 to satisfy Apple's June 2016
+ * DNS64/NAT64 requirements for app approval. Disabling this option may cause
+ * issues during app approval.
+ *
+ * https://developer.apple.com/library/ios/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/UnderstandingandPreparingfortheIPv6Transition/UnderstandingandPreparingfortheIPv6Transition.html
+ *
+ * This new default may cause connectivity issues for misconfigured servers that have
+ * both A and AAAA DNS records but don't respond to IPv6. A proper solution to this
+ * is to fix your XMPP server and/or DNS entries. However, when Happy Eyeballs
+ * (RFC 6555) is implemented upstream in GCDAsyncSocket it should resolve the issue 
+ * of misconfigured servers because it will try both the preferred protocol (IPv6) and
+ * and fallback protocol (IPv4) after a 300ms delay.
+ *
+ * Any changes to this option MUST be done before calling connect.
+ *
+ * The default value is YES.
+ **/
+@property (assign, readwrite) BOOL preferIPv6;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark State
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -111,6 +111,7 @@ enum XMPPStreamConfig
     XMPPStreamStartTLSPolicy startTLSPolicy;
     BOOL skipStartSession;
     BOOL validatesResponses;
+    BOOL preferIPv6;
 	
 	id <XMPPSASLAuthentication> auth;
 	id <XMPPCustomBinding> customBinding;
@@ -195,6 +196,7 @@ enum XMPPStreamConfig
     idTracker = [[XMPPIDTracker alloc] initWithStream:self dispatchQueue:xmppQueue];
 	
 	receipts = [[NSMutableArray alloc] init];
+    preferIPv6 = YES;
 }
 
 /**
@@ -210,6 +212,7 @@ enum XMPPStreamConfig
 		
 		// Initialize socket
 		asyncSocket = [[GCDAsyncSocket alloc] initWithDelegate:self delegateQueue:xmppQueue];
+        asyncSocket.IPv4PreferredOverIPv6 = !preferIPv6;
 	}
 	return self;
 }
@@ -391,6 +394,30 @@ enum XMPPStreamConfig
 		block();
 	else
 		dispatch_async(xmppQueue, block);
+}
+
+- (void) setPreferIPv6:(BOOL)_preferIPv6 {
+    dispatch_block_t block = ^{
+        preferIPv6 = _preferIPv6;
+    };
+    
+    if (dispatch_get_specific(xmppQueueTag))
+        block();
+    else
+        dispatch_async(xmppQueue, block);
+}
+
+- (BOOL) preferIPv6 {
+    __block BOOL result;
+    dispatch_block_t block = ^{
+        result = preferIPv6;
+    };
+    
+    if (dispatch_get_specific(xmppQueueTag))
+        block();
+    else
+        dispatch_sync(xmppQueue, block);
+    return result;
 }
 
 - (XMPPJID *)myJID
@@ -1256,6 +1283,7 @@ enum XMPPStreamConfig
 		
 		// Initailize socket
 		asyncSocket = [[GCDAsyncSocket alloc] initWithDelegate:self delegateQueue:xmppQueue];
+        asyncSocket.IPv4PreferredOverIPv6 = !preferIPv6;
 		
 		NSError *connectErr = nil;
 		result = [asyncSocket connectToAddress:remoteAddr error:&connectErr];


### PR DESCRIPTION
You should make sure you're using the latest release of CocoaAsyncSocket (7.5.1 or higher) if your IPv6 network is unreliable so the IPv4 fallback works. 