### PR TITLE
Fix for subject change error "invalid from"

### DIFF
--- a/Extensions/XEP-0045/XMPPRoom.m
+++ b/Extensions/XEP-0045/XMPPRoom.m
@@ -491,7 +491,7 @@ enum XMPPRoomState
     NSXMLElement *subject = [NSXMLElement elementWithName:@"subject" stringValue:newRoomSubject];
     
     XMPPMessage *message = [XMPPMessage message];
-    [message addAttributeWithName:@"from" stringValue:[myRoomJID full]];
+    [message addAttributeWithName:@"from" stringValue:[xmppStream.myJID full]];
     [message addChild:subject];
     
     [self sendMessage:message];


### PR DESCRIPTION
Fixes bug where server answers with „invalid from“ error on attempt to change subject.

Set from to myJID instead of myRoomJID in subjet change message.
See example in http://xmpp.org/extensions/xep-0045.html#subject-mod.

I'm not sure if other servers handle it different but ejabberd just closes the connection if the roomjid of the user is used. However, the XEP description means usage of the "normal" jid and this PR will fix that. 