### PR TITLE
"id" attribute is required for IQ stanzas

### DIFF
--- a/Extensions/ProcessOne/XMPPProcessOne.m
+++ b/Extensions/ProcessOne/XMPPProcessOne.m
@@ -148,7 +148,7 @@ NSString *const XMPPProcessOneSessionDate = @"XMPPProcessOneSessionDate";
 		
 		NSXMLElement *disable = [NSXMLElement elementWithName:@"disable" xmlns:@"p1:push"];
 		
-		XMPPIQ *iq = [XMPPIQ iqWithType:@"set" child:disable];
+		XMPPIQ *iq = [XMPPIQ iqWithType:@"set" elementID:[XMPPStream generateUUID] child:disable];
 		
 		[xmppStream sendElement:iq];
 		pushConfigurationSent = YES;

--- a/Extensions/XEP-0357/XMPPIQ+XEP_0357.m
+++ b/Extensions/XEP-0357/XMPPIQ+XEP_0357.m
@@ -9,6 +9,7 @@
 #import "XMPPIQ+XEP_0357.h"
 #import "XMPPJID.h"
 #import "NSXMLElement+XMPP.h"
+#import "XMPPStream.h"
 
 NSString *const XMPPPushXMLNS = @"urn:xmpp:push:0";
 
@@ -38,7 +39,7 @@ NSString *const XMPPPushXMLNS = @"urn:xmpp:push:0";
         [enableElement addChild:dataForm];
     }
     
-    return [self iqWithType:@"set" child:enableElement];
+    return [self iqWithType:@"set" elementID:[XMPPStream generateUUID] child:enableElement];
     
 }
 
@@ -49,7 +50,7 @@ NSString *const XMPPPushXMLNS = @"urn:xmpp:push:0";
     if ([node length]) {
         [disableElement addAttributeWithName:@"node" stringValue:node];
     }
-    return [self iqWithType:@"set" child:disableElement];
+    return [self iqWithType:@"set" elementID:[XMPPStream generateUUID] child:disableElement];
 }
 
 @end

--- a/Xcode/Testing-Shared/XMPPPushTests.swift
+++ b/Xcode/Testing-Shared/XMPPPushTests.swift
@@ -28,7 +28,10 @@ class XMPPPushTests: XCTestCase {
         let node = "yxs32uqsflafdk3iuqo"
         let enableStanza =  XMPPIQ.enableNotificationsElementWithJID(jid, node: node, options: nil)
         XCTAssertNotNil(enableStanza,"No Stanza")
-        
+
+        XCTAssertNotNil(enableStanza.attributeForName("id"), "No id attribute")
+        enableStanza.removeAttributeForName("id")
+
         /**
         <iq type="set">
             <enable xmlns="urn:xmpp:push:0" jid="push-5.client.example" node="yxs32uqsflafdk3iuqo"></enable>
@@ -43,7 +46,10 @@ class XMPPPushTests: XCTestCase {
         let options = ["secret":"eruio234vzxc2kla-91"]
         let enableStanza =  XMPPIQ.enableNotificationsElementWithJID(jid, node: node, options: options)
         XCTAssertNotNil(enableStanza,"No Stanza")
-        
+
+        XCTAssertNotNil(enableStanza.attributeForName("id"), "No id attribute")
+        enableStanza.removeAttributeForName("id")
+
         /**
         <iq type="set">
             <enable xmlns="urn:xmpp:push:0" jid="push-5.client.example" node="yxs32uqsflafdk3iuqo">
@@ -63,6 +69,10 @@ class XMPPPushTests: XCTestCase {
         let disableStanza = XMPPIQ.disableNotificationsElementWithJID(jid, node: node)
         XCTAssertNotNil(disableStanza)
         print("\(disableStanza.XMLString)")
+
+        XCTAssertNotNil(disableStanza.attributeForName("id"), "No id attribute")
+        disableStanza.removeAttributeForName("id")
+
         /**
         <iq type="set">
             <disable xmlns="urn:xmpp:push:0" jid="push-5.client.example" node="yxs32uqsflafdk3iuqo"></disable>


### PR DESCRIPTION
ejabberd 16.09+ rejects stanzas that don't match the specs, so enabling `xmpp:push` feature from ChatSecure does not work.