### PR TITLE
Remove Emoji from nickname before joining a room

### DIFF
--- a/Extensions/XEP-0045/XMPPRoom.h
+++ b/Extensions/XEP-0045/XMPPRoom.h
@@ -1,3 +1,4 @@
+#include <unicode/utf8.h>
 #import <Foundation/Foundation.h>
 #import "XMPP.h"
 #import "XMPPRoomMessage.h"
@@ -316,4 +317,12 @@ static NSString *const XMPPMUCOwnerNamespace = @"http://jabber.org/protocol/muc#
 - (void)xmppRoom:(XMPPRoom *)sender didNotEditPrivileges:(XMPPIQ *)iqError;
 - (void)xmppRoomDidChangeSubject:(XMPPRoom *)sender;
 
+@end
+
+
+@interface NSString (EmojiExtension)
+/**
+ * Invoked before joining a room. It removes Emoji from desiredNickname.
+ **/
+- (NSString *)stringByRemovingEmoji;
 @end

--- a/Extensions/XEP-0045/XMPPRoom.m
+++ b/Extensions/XEP-0045/XMPPRoom.m
@@ -270,7 +270,7 @@ enum XMPPRoomState
 		
 		// Check state and update variables
 		
-		if (![self preJoinWithNickname:desiredNickname])
+		if (![self preJoinWithNickname:[desiredNickname stringByRemovingEmoji]])
 		{
 			return;
 		}
@@ -1186,6 +1186,28 @@ enum XMPPRoomState
 		[item addAttributeWithName:@"jid" stringValue:[jid full]];
 	
 	return item;
+}
+
+@end
+
+
+@implementation NSString (EmojiExtension)
+
+- (NSString *)stringByRemovingEmoji {
+    NSData *d = [self dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:NO];
+    if(!d) return nil;
+    const char *buf = d.bytes;
+    unsigned int len = (unsigned int)[d length];
+    char *s = (char *)malloc(len);
+    unsigned int ii = 0, oi = 0; // in index, out index
+    UChar32 uc;
+    while (ii < len) {
+        U8_NEXT_UNSAFE(buf, ii, uc);
+        if(0x2100 <= uc && uc <= 0x26ff) continue;
+        if(0x1d000 <= uc && uc <= 0x1f77f) continue;
+        U8_APPEND_UNSAFE(s, oi, uc);
+    }
+    return [[NSString alloc] initWithBytesNoCopy:s length:oi encoding:NSUTF8StringEncoding freeWhenDone:YES];
 }
 
 @end

--- a/Xcode/Examples/DesktopXMPP/MucController.m
+++ b/Xcode/Examples/DesktopXMPP/MucController.m
@@ -51,7 +51,7 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 		// xmppRoomStorage automatically inherits the delegate(s) of it's parent xmppRoom
 		
 		[xmppRoom activate:xmppStream];
-		[xmppRoom joinRoomUsingNickname:@"xmppFrameowrkMucTest" history:nil];
+		[xmppRoom joinRoomUsingNickname:@"xmppFrameworkMucTest" history:nil];
 		
 		#if USE_HYBRID_STORAGE
 		messages  = [[NSMutableArray alloc] init];


### PR DESCRIPTION
As reported in the issue #879, it isn’t possible to join a MUC with a
nickname that contains some Emojis.
Quick fix that prevent failure.