### PR TITLE
Fixed the wrong initial presence bug (#108)

### DIFF
--- a/Extensions/Roster/CoreDataStorage/XMPPUserCoreDataStorageObject.m
+++ b/Extensions/Roster/CoreDataStorage/XMPPUserCoreDataStorageObject.m
@@ -313,6 +313,10 @@ static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
 
 - (void)updateWithPresence:(XMPPPresence *)presence streamBareJidStr:(NSString *)streamBareJidStr
 {
+    if (!presence.from.isFull) {
+        return;
+    }
+    
 	XMPPResourceCoreDataStorageObject *resource =
 	    (XMPPResourceCoreDataStorageObject *)[self resourceForJID:[presence from]];
 	


### PR DESCRIPTION
Due to the XMPP reference the resource is a distinct device or location and it is addressed with a full JID. The effect, described in #108, is occurred because of saving subscription presences with bare JIDs.  