### PR TITLE
Custom filtering of incoming PEP event messages

### DIFF
--- a/Extensions/XEP-0060/XMPPPubSub.h
+++ b/Extensions/XEP-0060/XMPPPubSub.h
@@ -30,6 +30,22 @@
 @property (nonatomic, strong, readonly) XMPPJID *serviceJID;
 
 /**
+ * An array of publisher JIDs whose event messages will be received by the module.
+ * Only effective for PEP modules (serviceJID == nil). If the value is nil (the default), publisher filter is not applied.
+ * This filter is applied together with the node-based one.
+ * If both this and pepNodes are nil, only own events will be received.
+**/
+@property (atomic, copy, readwrite) NSArray<XMPPJID *> *pepPublisherJIDs;
+
+/**
+ * An array of nodes whose event messages will be received by the module.
+ * Only effective for PEP modules (serviceJID == nil). If the value is nil (the default), node filter is not applied.
+ * This filter is applied together with the publisher-based one.
+ * If both this and pepPublisherJIDs are nil, only own events will be received.
+**/
+@property (atomic, copy, readwrite) NSArray<NSString *> *pepNodes;
+
+/**
  * Sends a subscription request for the given node name.
  *
  * @param node
@@ -369,7 +385,6 @@
 - (void)xmppPubSub:(XMPPPubSub *)sender didRetrieveItems:(XMPPIQ *)iq fromNode:(NSString *)node;
 - (void)xmppPubSub:(XMPPPubSub *)sender didNotRetrieveItems:(XMPPIQ *)iq fromNode:(NSString *)node;
 
-- (BOOL)xmppPubSub:(XMPPPubSub *)sender shouldReceiveForeignMessage:(XMPPMessage *)message;
 - (void)xmppPubSub:(XMPPPubSub *)sender didReceiveMessage:(XMPPMessage *)message;
 
 @end

--- a/Extensions/XEP-0060/XMPPPubSub.h
+++ b/Extensions/XEP-0060/XMPPPubSub.h
@@ -369,6 +369,7 @@
 - (void)xmppPubSub:(XMPPPubSub *)sender didRetrieveItems:(XMPPIQ *)iq fromNode:(NSString *)node;
 - (void)xmppPubSub:(XMPPPubSub *)sender didNotRetrieveItems:(XMPPIQ *)iq fromNode:(NSString *)node;
 
+- (BOOL)xmppPubSub:(XMPPPubSub *)sender shouldReceiveForeignMessage:(XMPPMessage *)message;
 - (void)xmppPubSub:(XMPPPubSub *)sender didReceiveMessage:(XMPPMessage *)message;
 
 @end

--- a/Extensions/XEP-0060/XMPPPubSub.m
+++ b/Extensions/XEP-0060/XMPPPubSub.m
@@ -18,6 +18,9 @@
 {
 	XMPPJID *serviceJID;
 	XMPPJID *myJID;
+    
+    NSArray<XMPPJID *> *pepPublisherJIDs;
+    NSArray<NSString *> *pepNodes;
 	
 	NSMutableDictionary *subscribeDict;
 	NSMutableDictionary *unsubscribeDict;
@@ -37,6 +40,66 @@
 }
 
 @synthesize serviceJID;
+
+- (NSArray<XMPPJID *> *)pepPublisherJIDs
+{
+    __block NSArray<XMPPJID *> *result;
+    
+    dispatch_block_t block = ^{
+        result = pepPublisherJIDs;
+    };
+    
+    if (dispatch_get_specific(moduleQueueTag))
+        block();
+    else
+        dispatch_sync(moduleQueue, block);
+    
+    return result;
+}
+
+- (void)setPepPublisherJIDs:(NSArray<XMPPJID *> *)pepPublisherJIDs
+{
+    NSArray<XMPPJID *> *newValue = [pepPublisherJIDs copy];
+    
+    dispatch_block_t block = ^{
+        self->pepPublisherJIDs = newValue;
+    };
+    
+    if (dispatch_get_specific(moduleQueueTag))
+        block();
+    else
+        dispatch_async(moduleQueue, block);
+}
+
+- (NSArray<NSString *> *)pepNodes
+{
+    __block NSArray<NSString *> *result;
+    
+    dispatch_block_t block = ^{
+        result = pepNodes;
+    };
+    
+    if (dispatch_get_specific(moduleQueueTag))
+        block();
+    else
+        dispatch_sync(moduleQueue, block);
+    
+    return result;
+}
+
+- (void)setPepNodes:(NSArray<NSString *> *)pepNodes
+{
+    NSArray<NSString *> *newValue = [pepNodes copy];
+    
+    dispatch_block_t block = ^{
+        self->pepNodes = newValue;
+    };
+    
+    if (dispatch_get_specific(moduleQueueTag))
+        block();
+    else
+        dispatch_async(moduleQueue, block);
+}
 
 - (id)init
 {
@@ -433,51 +496,50 @@
 **/
 - (void)xmppStream:(XMPPStream *)sender didReceiveMessage:(XMPPMessage *)message
 {
-	// Check to see if message is from our PubSub/PEP service
-    BOOL isOurMessage;
-	if (serviceJID) {
-		isOurMessage = [serviceJID isEqualToJID:[message from]];
-	}
-	else {
-		isOurMessage = [myJID isEqualToJID:[message from] options:XMPPJIDCompareBare];
-	}
-	
-	// <message from='pubsub.foo.co.uk' to='admin@foo.co.uk'>
-	//   <event xmlns='http://jabber.org/protocol/pubsub#event'>
-	//     <items node='/pubsub.foo'>
-	//       <item id='5036AA52A152B'>
-	//         [... entry ...]
-	//       </item>
-	//     </items>
-	//   </event>
-	// </message>
-	
-	NSXMLElement *event = [message elementForName:@"event" xmlns:XMLNS_PUBSUB_EVENT];
+    // <message from='pubsub.foo.co.uk' to='admin@foo.co.uk'>
+    //   <event xmlns='http://jabber.org/protocol/pubsub#event'>
+    //     <items node='/pubsub.foo'>
+    //       <item id='5036AA52A152B'>
+    //         [... entry ...]
+    //       </item>
+    //     </items>
+    //   </event>
+    // </message>
+    
+    NSXMLElement *event = [message elementForName:@"event" xmlns:XMLNS_PUBSUB_EVENT];
     if (!event) return;
     
-    SEL delegateSelector = @selector(xmppPubSub:shouldReceiveForeignMessage:);
-    
-    if (!isOurMessage) {
-        GCDMulticastDelegateEnumerator *delegateEnumerator = [multicastDelegate delegateEnumerator];
-        
-        __block BOOL shouldReceiveForeignMessage = [multicastDelegate hasDelegateThatRespondsToSelector:delegateSelector];
-        
-        id del;
-        dispatch_queue_t dq;
-        
-        while (shouldReceiveForeignMessage && [delegateEnumerator getNextDelegate:&del delegateQueue:&dq forSelector:delegateSelector]) {
-            dispatch_block_t delegateBlock = ^{ @autoreleasepool {
-                shouldReceiveForeignMessage = [del xmppPubSub:self shouldReceiveForeignMessage:message];
-            }};
-            
-            if (dispatch_queue_get_specific(dq, moduleQueueTag))
-                delegateBlock();
-            else
-                dispatch_sync(dq, delegateBlock);
+	// Check to see if message is from our PubSub/PEP service
+	if (serviceJID) {
+		if (![serviceJID isEqualToJID:[message from]]) return;
+	}
+	else {
+        if (self.pepPublisherJIDs) {
+            BOOL isFromPEPPublisher = NO;
+            for (XMPPJID *pepPublisherJID in self.pepPublisherJIDs) {
+                if ([pepPublisherJID isEqualToJID:[message from] options:XMPPJIDCompareBare]) {
+                    isFromPEPPublisher = YES;
+                    break;
+                }
+            }
+            if (!isFromPEPPublisher) return;
+        }
+
+        if (self.pepNodes) {
+            for (NSString *eventType in @[@"collection", @"configuration", @"delete", @"items", @"purge", @"subscription"]) {
+                NSXMLElement *eventChildElement = [event elementForName:eventType];
+                if (!eventChildElement) continue;
+                
+                NSString *node = [eventChildElement attributeStringValueForName:@"node"];
+                if (!node || ![self.pepNodes containsObject:node]) return;
+                break;
+            }
         }
         
-        if (!shouldReceiveForeignMessage) return;
-    }
+        if (!self.pepPublisherJIDs && !self.pepNodes) {
+            if (![myJID isEqualToJID:[message from] options:XMPPJIDCompareBare]) return;
+        }
+	}
     
     [multicastDelegate xmppPubSub:self didReceiveMessage:message];
 }

--- a/Xcode/Testing-Shared/XMPPPubSubTests.m
+++ b/Xcode/Testing-Shared/XMPPPubSubTests.m
@@ -1,4 +1,4 @@
-import <XCTest/XCTest.h>
+#import <XCTest/XCTest.h>
 #import "XMPPMockStream.h"
 
 @interface XMPPPubSubTests : XCTestCase <XMPPPubSubDelegate>

--- a/Xcode/Testing-Shared/XMPPPubSubTests.m
+++ b/Xcode/Testing-Shared/XMPPPubSubTests.m
@@ -1,0 +1,94 @@
+import <XCTest/XCTest.h>
+#import "XMPPMockStream.h"
+
+@interface XMPPPubSubTests : XCTestCase <XMPPPubSubDelegate>
+
+@property (nonatomic, strong) XMPPMockStream *testStream;
+@property (nonatomic, strong) XMPPPubSub *pepPubSub;
+@property (nonatomic, strong) NSMutableArray<XMPPMessage *> *delegateMessages;
+
+@end
+
+@implementation XMPPPubSubTests
+
+- (void)setUp {
+    [super setUp];
+
+    self.testStream = [[XMPPMockStream alloc] init];
+    
+    self.pepPubSub = [[XMPPPubSub alloc] initWithServiceJID:nil];
+    [self.pepPubSub addDelegate:self delegateQueue:self.pepPubSub.moduleQueue];
+    [self.pepPubSub activate:self.testStream];
+    
+    self.delegateMessages = [[NSMutableArray alloc] init];
+}
+
+- (void)testPEPPublisherFiltering {
+    NSString *allowedPublisherJIDString = @"test.user@erlang-solutions.com";
+    NSString *filteredPublisherJIDString = @"unknown@erlang-solutions.com";
+    
+    self.pepPubSub.pepPublisherJIDs = @[[XMPPJID jidWithString:allowedPublisherJIDString]];
+    
+    XCTestExpectation *delegateExpectation = [self expectationWithDescription:@"PEP publisher filter expectation"];
+    
+    [self fakePEPEventMessageWithPublisherJIDString:allowedPublisherJIDString node:@"pep_node"];
+    [self fakePEPEventMessageWithPublisherJIDString:filteredPublisherJIDString node:@"pep_node"];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertEqual(self.delegateMessages.count, 1);
+        XCTAssertEqualObjects([[self.delegateMessages.firstObject from] full], allowedPublisherJIDString);
+        [delegateExpectation fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout:2 handler:^(NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"Error: %@", error);
+        }
+    }];
+}
+
+- (void)testPEPNodeFiltering {
+    NSString *allowedNode = @"pep_node";
+    NSString *allowedNodePublisherJIDString = @"test.user@erlang-solutions.com";
+    NSString *filteredNode = @"unknown_node";
+    
+    self.pepPubSub.pepNodes = @[allowedNode];
+    
+    XCTestExpectation *delegateExpectation = [self expectationWithDescription:@"PEP node filter expectation"];
+    
+    [self fakePEPEventMessageWithPublisherJIDString:allowedNodePublisherJIDString node:allowedNode];
+    [self fakePEPEventMessageWithPublisherJIDString:@"unknown@erlang-solutions.com" node:filteredNode];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssertEqual(self.delegateMessages.count, 1);
+        XCTAssertEqualObjects([[self.delegateMessages.firstObject from] full], allowedNodePublisherJIDString);
+        [delegateExpectation fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout:2 handler:^(NSError * _Nullable error) {
+        if (error) {
+            NSLog(@"Error: %@", error);
+        }
+    }];
+}
+
+- (void)xmppPubSub:(XMPPPubSub *)sender didReceiveMessage:(XMPPMessage *)message
+{
+    [self.delegateMessages addObject:message];
+}
+
+- (void)fakePEPEventMessageWithPublisherJIDString:(NSString *)publisherJIDString node:(NSString *)node {
+    NSMutableString *s = [NSMutableString string];
+    [s appendFormat:@"<message from='%@'>", publisherJIDString];
+    [s appendString:@"   <event xmlns='http://jabber.org/protocol/pubsub#event'>"];
+    [s appendFormat:@"      <items node='%@'>", node];
+    [s appendString:@"         <item/>"];
+    [s appendString:@"      </items>"];
+    [s appendString:@"   </event>"];
+    [s appendString:@"</message>"];
+    
+    NSXMLDocument *doc = [[NSXMLDocument alloc] initWithXMLString:s options:0 error:NULL];
+    [self.testStream fakeMessageResponse:[XMPPMessage messageFromElement:[doc rootElement]]];
+}
+
+@end

--- a/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D99C5E0D1D99C48100FB068A /* OMEMOModuleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0A1D99C48100FB068A /* OMEMOModuleTests.m */; };
 		D99C5E0E1D99C48100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
+		DD1E732C1ED86B7D009B529B /* XMPPPubSubTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */; };
 		FDD2AB232C05507F2045FFFC /* Pods_XMPPFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD0B17267211A912DE2098E /* Pods_XMPPFrameworkTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -53,6 +54,7 @@
 		D99C5E0B1D99C48100FB068A /* OMEMOTestStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OMEMOTestStorage.h; path = "../../Testing-Shared/OMEMOTestStorage.h"; sourceTree = "<group>"; };
 		D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
+		DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPubSubTests.m; path = "../../Testing-Shared/XMPPPubSubTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +107,7 @@
 				D973A0791D2F18040096F3ED /* XMPPStorageHintTests.m */,
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
+				DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 				D973A06E1D2F18030096F3ED /* XMPPFrameworkTests-Bridging-Header.h */,
 			);
@@ -262,6 +265,7 @@
 				D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */,
 				D973A0851D2F18040096F3ED /* XMPPStorageHintTests.m in Sources */,
 				D973A0891D2F18310096F3ED /* XMPPSwift.swift in Sources */,
+				DD1E732C1ED86B7D009B529B /* XMPPPubSubTests.m in Sources */,
 				D973A0871D2F18040096F3ED /* XMPPvCardTests.m in Sources */,
 				D99C5E0E1D99C48100FB068A /* OMEMOTestStorage.m in Sources */,
 			);


### PR DESCRIPTION
This reverts #249 and introduces custom delegate-driven incoming message filtering. Fixes #918.