### PR TITLE
Ignore user’s resource when storing MUC Light messages

### DIFF
--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
@@ -125,7 +125,7 @@
 	
 	XMPPJID *myRoomJID = [XMPPJID jidWithUser:room.roomJID.user
 									   domain:room.roomJID.domain
-									 resource:xmppStream.myJID.full];
+									 resource:xmppStream.myJID.bare];
 	
 	XMPPJID *roomJID = room.roomJID;
 	XMPPJID *messageJID = isOutgoing ? myRoomJID : [message from];


### PR DESCRIPTION
Storing room message JIDs of the form `room@muclight.domain/user@user.domain/user.resource` causes them to be misidentified as incoming when the sender gets assigned a different resource next time they connect.