### PR TITLE
Force XMPPReconnect connection attempts

### DIFF
--- a/Core/XMPPStream.h
+++ b/Core/XMPPStream.h
@@ -365,6 +365,13 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
 - (BOOL)connectP2PWithSocket:(GCDAsyncSocket *)acceptedSocket error:(NSError **)errPtr;
 
 /**
+ * Aborts any in-progress connection attempt. Has no effect if the stream is already connected or disconnected.
+ * 
+ * Will dispatch the xmppStreamWasToldToAbortConnect: delegate method.
+**/
+- (void)abortConnecting;
+
+/**
  * Disconnects from the remote host by closing the underlying TCP socket connection.
  * The terminating </stream:stream> element is not sent to the server.
  * 
@@ -1075,6 +1082,11 @@ extern const NSTimeInterval XMPPStreamTimeoutNone;
  * This method is called if the XMPP stream's connect times out.
 **/
 - (void)xmppStreamConnectDidTimeout:(XMPPStream *)sender;
+
+/**
+ * Invoked when -abortConnecting is called while a connection attempt was in progress.
+**/
+- (void)xmppStreamWasToldToAbortConnect:(XMPPStream *)sender;
 
 /**
  * This method is called after the stream is closed.

--- a/Extensions/Reconnect/XMPPReconnect.m
+++ b/Extensions/Reconnect/XMPPReconnect.m
@@ -536,9 +536,9 @@ static void XMPPReconnectReachabilityCallback(SCNetworkReachabilityRef target, S
 	
 	if (([self manuallyStarted]) || ([self autoReconnect] && [self shouldReconnect])) 
 	{
-		if ([xmppStream isDisconnected] && ([self queryingDelegates] == NO))
+		if (![xmppStream isConnected] && ([self queryingDelegates] == NO))
 		{
-			// The xmpp stream is disconnected, and is not attempting reconnection
+			// The xmpp stream is not connected, otherwise any attempt in progress will be aborted
 			
 			// Delegate rules:
 			// 
@@ -597,6 +597,8 @@ static void XMPPReconnectReachabilityCallback(SCNetworkReachabilityRef target, S
 						[self setMultipleReachabilityChanges:NO];
 						previousReachabilityFlags = reachabilityFlags;
 						
+                        [xmppStream abortConnecting];
+                        
                         if (self.usesOldSchoolSecureConnect)
                         {
                             [xmppStream oldSchoolSecureConnectWithTimeout:XMPPStreamTimeoutNone error:nil];


### PR DESCRIPTION
Fixes #935.

With this change, XMPPReconnect will abort any in-progress connection attempt and initiate a new one on every timer/reachability callback. 