### PR TITLE
MUC Light members list in-module storage

### DIFF
--- a/Extensions/XMPPMUCLight/XMPPRoomLight.h
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.h
@@ -24,6 +24,7 @@
 
 - (nonnull NSString *)roomname;
 - (nonnull NSString *)subject;
+- (nonnull NSArray<NSXMLElement*> *)knownMembersList;
 
 - (nonnull instancetype)initWithJID:(nonnull XMPPJID *)roomJID roomname:(nonnull NSString *) roomname;
 - (nonnull instancetype)initWithRoomLightStorage:(nullable id <XMPPRoomLightStorage>)storage jid:(nonnull XMPPJID *)aRoomJID roomname:(nonnull NSString *)aRoomname dispatchQueue:(nullable dispatch_queue_t)queue;

--- a/Extensions/XMPPMUCLight/XMPPRoomLight.h
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.h
@@ -64,7 +64,7 @@
 - (void)xmppRoomLight:(nonnull XMPPRoomLight *)sender didAddUsers:(nonnull XMPPIQ*) iqResult;
 - (void)xmppRoomLight:(nonnull XMPPRoomLight *)sender didFailToAddUsers:(nonnull XMPPIQ*)iq;
 
-- (void)xmppRoomLight:(nonnull XMPPRoomLight *)sender didFetchMembersList:(nonnull NSArray<NSXMLElement*> *)items;
+- (void)xmppRoomLight:(nonnull XMPPRoomLight *)sender didFetchMembersList:(nonnull XMPPIQ *)iqResult;
 - (void)xmppRoomLight:(nonnull XMPPRoomLight *)sender didFailToFetchMembersList:(nonnull XMPPIQ *)iq;
 
 - (void)xmppRoomLight:(nonnull XMPPRoomLight *)sender didDestroyRoomLight:(nonnull XMPPIQ*) iqResult;

--- a/Extensions/XMPPMUCLight/XMPPRoomLight.m
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.m
@@ -399,7 +399,7 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
             [self setKnownMembersList:items];
         }
 
-		[multicastDelegate xmppRoomLight:self didFetchMembersList:items];
+		[multicastDelegate xmppRoomLight:self didFetchMembersList:iq];
 	}else{
 		[multicastDelegate xmppRoomLight:self didFailToFetchMembersList:iq];
 	}

--- a/Xcode/Testing-Shared/XMPPRoomLightTests.m
+++ b/Xcode/Testing-Shared/XMPPRoomLightTests.m
@@ -294,7 +294,7 @@
 	}];
 }
 
-- (void)xmppRoomLight:(XMPPRoomLight *)sender didFetchMembersList:(NSArray *)items {
+- (void)xmppRoomLight:(XMPPRoomLight *)sender didFetchMembersList:(XMPPIQ *)iqResult {
 	NSXMLElement *user1 = [[sender knownMembersList] firstObject];
 	NSXMLElement *user3 = [[sender knownMembersList] lastObject];
 	XCTAssertEqualObjects([user1 attributeForName:@"affiliation"].stringValue, @"owner");

--- a/Xcode/Testing-Shared/XMPPRoomLightTests.m
+++ b/Xcode/Testing-Shared/XMPPRoomLightTests.m
@@ -295,8 +295,8 @@
 }
 
 - (void)xmppRoomLight:(XMPPRoomLight *)sender didFetchMembersList:(NSArray *)items {
-	NSXMLElement *user1 = [items firstObject];
-	NSXMLElement *user3 = [items lastObject];
+	NSXMLElement *user1 = [[sender knownMembersList] firstObject];
+	NSXMLElement *user3 = [[sender knownMembersList] lastObject];
 	XCTAssertEqualObjects([user1 attributeForName:@"affiliation"].stringValue, @"owner");
 	XCTAssertEqualObjects(user1.stringValue, @"user1@shakespeare.lit");
 	XCTAssertEqualObjects([user3 attributeForName:@"affiliation"].stringValue, @"member");


### PR DESCRIPTION
Fixes #942.

This introduces the `knownMembersList` property which holds the most recently fetched occupants list. This is akin to how the existing configuration-derived properties work (`roomname`, `subject`).

The PR also changes `xmppRoomLight:didFetchMembersList:` callback to return the full result IQ. The rationale is as follows:
* Returning only an empty array after a version-matched fetch appears confusing
* All the other IQ response callbacks return full result stanzas