### PR TITLE
Fix missing "id" attribute in some IQ stanzas

### DIFF
--- a/Core/XMPPIQ.m
+++ b/Core/XMPPIQ.m
@@ -116,6 +116,8 @@
 		
 		if (eid)
 			[self addAttributeWithName:@"id" stringValue:eid];
+		else
+			[self addAttributeWithName:@"id" stringValue:[[NSUUID UUID] UUIDString]];
 		
 		if (childElement)
 			[self addChild:childElement];

--- a/Extensions/Roster/XMPPRoster.m
+++ b/Extensions/Roster/XMPPRoster.m
@@ -515,9 +515,7 @@ enum XMPPRosterFlags
 	NSXMLElement *query = [NSXMLElement elementWithName:@"query" xmlns:@"jabber:iq:roster"];
 	[query addChild:item];
 
-	NSXMLElement *iq = [NSXMLElement elementWithName:@"iq"];
-	[iq addAttributeWithName:@"type" stringValue:@"set"];
-	[iq addChild:query];
+	XMPPIQ *iq = [XMPPIQ iqWithType:@"set" child:query];
 
 	[xmppStream sendElement:iq];
 


### PR DESCRIPTION
This pull request addresses issue #908, fixing all the instances I found where the "id" attribute was missing from IQ stanzas and thereby fixing compatibility with ejabberd version 17.01