### PR TITLE
XMPPReconnect forced retries fix

### DIFF
--- a/Extensions/Reconnect/XMPPReconnect.m
+++ b/Extensions/Reconnect/XMPPReconnect.m
@@ -391,6 +391,10 @@ static void XMPPReconnectReachabilityCallback(SCNetworkReachabilityRef target, S
 		
 		dispatch_source_set_event_handler(reconnectTimer, ^{ @autoreleasepool {
 			
+            // It is likely that reconnectTimerInterval is shorter than socket's timeout value.
+            // In such case we want to abort the current connection attempt (if any) and start a new one.
+            [self setShouldRestartReconnect:YES];
+            
 			[self maybeAttemptReconnect];
 			
 		}});

--- a/Extensions/Reconnect/XMPPReconnect.m
+++ b/Extensions/Reconnect/XMPPReconnect.m
@@ -545,9 +545,9 @@ static void XMPPReconnectReachabilityCallback(SCNetworkReachabilityRef target, S
 	
 	if (([self manuallyStarted]) || ([self autoReconnect] && [self shouldReconnect])) 
 	{
-		if (![xmppStream isConnected] && ([self queryingDelegates] == NO))
+		if ([xmppStream isDisconnected] && ([self queryingDelegates] == NO))
 		{
-			// The xmpp stream is not connected, otherwise any attempt in progress will be aborted
+			// The xmpp stream is disconnected, and is not attempting reconnection
 			
 			// Delegate rules:
 			// 
@@ -606,8 +606,6 @@ static void XMPPReconnectReachabilityCallback(SCNetworkReachabilityRef target, S
 						[self setShouldRestartReconnect:NO];
 						previousReachabilityFlags = reachabilityFlags;
 						
-                        [xmppStream abortConnecting];
-                        
                         if (self.usesOldSchoolSecureConnect)
                         {
                             [xmppStream oldSchoolSecureConnectWithTimeout:XMPPStreamTimeoutNone error:nil];
@@ -642,6 +640,10 @@ static void XMPPReconnectReachabilityCallback(SCNetworkReachabilityRef target, S
 		{
 			// The xmpp stream is already attempting a connection.
 			
+            if ([self shouldRestartReconnect])
+            {
+                [xmppStream abortConnecting];
+            }
 		}
 	}
 }


### PR DESCRIPTION
Fixes #946.

With this change, forced reconnect retry runs in the following properly sequenced steps:
1. A forced retry flag is raised when appropriate before triggering a reconnect attempt (reachability changed or a reconnect timer fired).
2. When a reconnect attempt is triggered while another one is still in progress, the forced retry flag triggers aborting the latter.
3. After the in progress attempt is completely aborted, the retry is started.