### PR TITLE
Allow storing MUC Light affiliation change messages

### DIFF
--- a/Extensions/XEP-0313/XMPPRoomLightCoreDataStorage+XEP_0313.m
+++ b/Extensions/XEP-0313/XMPPRoomLightCoreDataStorage+XEP_0313.m
@@ -1,5 +1,6 @@
 #import "XMPPRoomLightCoreDataStorage+XEP_0313.h"
 #import "XMPPRoomLightCoreDataStorageProtected.h"
+#import "XMPPRoomMessage.h"
 
 @implementation XMPPRoomLightCoreDataStorage (XEP_0313)
 
@@ -42,6 +43,15 @@
     fetchRequest.fetchLimit = 1;
     
     NSArray *results = [moc executeFetchRequest:fetchRequest error:NULL];
+    
+    if (messageBody.length == 0) {
+        // for non-body messages fall back to comparing <x> elements; this has to be done post-fetch as managed objects lack relevant attributes
+        results = [results filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
+            id<XMPPRoomMessage> evaluatedMessage = evaluatedObject;
+            return [[[[evaluatedMessage message] elementsForName:@"x"] valueForKey:@"XMLString"] isEqual:
+                    [[message elementsForName:@"x"] valueForKey:@"XMLString"]];
+        }]];
+    }
     
     return results && results.count == 0;
 }

--- a/Extensions/XMPPMUCLight/XMPPRoomLight.h
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.h
@@ -21,6 +21,7 @@
 
 @property (readonly, nonatomic, strong, nonnull) XMPPJID *roomJID;
 @property (readonly, nonatomic, strong, nonnull) NSString *domain;
+@property (nonatomic, assign) BOOL shouldStoreAffiliationChangeMessages;
 
 - (nonnull NSString *)roomname;
 - (nonnull NSString *)subject;

--- a/Extensions/XMPPMUCLight/XMPPRoomLight.m
+++ b/Extensions/XMPPMUCLight/XMPPRoomLight.m
@@ -660,19 +660,11 @@ static NSString *const XMPPRoomLightDestroy = @"urn:xmpp:muclight:0#destroy";
 		return; // Stanza isn't for our room
 	}
 
-	BOOL destroyRoom = false;
-	BOOL changeConfiguration = false;
-    BOOL changeAffiliantions = false;
-	NSArray <NSXMLElement*> *xElements = [message elementsForName:@"x"];
-	for (NSXMLElement *x in xElements) {
-		if ([x.xmlns isEqualToString:XMPPRoomLightDestroy]) {
-			destroyRoom = true;
-		} else if ([x.xmlns isEqualToString:XMPPRoomLightConfiguration]){
-			changeConfiguration = true;
-        } else if ([x.xmlns isEqualToString:XMPPRoomLightAffiliations]) {
-            changeAffiliantions = true;
-        }
-	}
+    // note: do not use [message elementsForName:@"x"] as this will fail to find namespace-qualified elements in Apple's NSXML implementation (DDXML works fine)
+	BOOL destroyRoom = [message elementsForLocalName:@"x" URI:XMPPRoomLightDestroy].count > 0;
+	BOOL changeConfiguration = [message elementsForLocalName:@"x" URI:XMPPRoomLightConfiguration].count > 0;;
+    BOOL changeAffiliantions = [message elementsForLocalName:@"x" URI:XMPPRoomLightAffiliations].count > 0;;
+    
 	// Is this a message we need to store (a chat message)?
 	//
 	// We store messages that from is full room-id@domain/user-who-sends-message

--- a/Xcode/Testing-Shared/XMPPRoomLightCoreDataStorageTests.m
+++ b/Xcode/Testing-Shared/XMPPRoomLightCoreDataStorageTests.m
@@ -43,7 +43,7 @@
 	self.checkDelegate = false;
 	XCTestExpectation *expectation = [self expectationWithDescription:@"receive message and correctly stored"];
 
-	XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"test.sqlite" storeOptions:nil];
+	XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"testReceiveMessageWithStorage.sqlite" storeOptions:nil];
     storage.autoRemovePreviousDatabaseFile = YES;
 
 	XMPPMockStream *streamTest = [[XMPPMockStream alloc] init];
@@ -91,7 +91,7 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"receive affiliation message and correctly stored"];
     
-    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"test.sqlite" storeOptions:nil];
+    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"testReceiveAffiliationMessageWithStorage.sqlite" storeOptions:nil];
     storage.autoRemovePreviousDatabaseFile = YES;
     
     XMPPMockStream *streamTest = [[XMPPMockStream alloc] init];
@@ -140,7 +140,7 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"message imported"];
     
-    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"test.sqlite" storeOptions:nil];
+    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"testImportMessage.sqlite" storeOptions:nil];
     storage.autoRemovePreviousDatabaseFile = YES;
     
     XMPPMockStream *streamTest = [[XMPPMockStream alloc] init];
@@ -186,7 +186,7 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"only one of two messages imported"];
     
-    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"test.sqlite" storeOptions:nil];
+    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"testImportMessageUniquing.sqlite" storeOptions:nil];
     storage.autoRemovePreviousDatabaseFile = YES;
     
     XMPPMockStream *streamTest = [[XMPPMockStream alloc] init];

--- a/Xcode/Testing-Shared/XMPPRoomLightCoreDataStorageTests.m
+++ b/Xcode/Testing-Shared/XMPPRoomLightCoreDataStorageTests.m
@@ -86,6 +86,55 @@
 	}];
 }
 
+- (void)testReceiveAffiliationMessageWithStorage {
+    self.checkDelegate = false;
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"receive affiliation message and correctly stored"];
+    
+    XMPPRoomLightCoreDataStorage *storage = [[XMPPRoomLightCoreDataStorage alloc] initWithDatabaseFilename:@"test.sqlite" storeOptions:nil];
+    storage.autoRemovePreviousDatabaseFile = YES;
+    
+    XMPPMockStream *streamTest = [[XMPPMockStream alloc] init];
+    streamTest.myJID = [XMPPJID jidWithString:@"myUser@domain.com"];
+    XMPPJID *jid = [XMPPJID jidWithString:@"room@domain.com"];
+    XMPPRoomLight *roomLight = [[XMPPRoomLight alloc] initWithRoomLightStorage:storage jid:jid roomname:@"test" dispatchQueue:nil];
+    roomLight.shouldStoreAffiliationChangeMessages = true;
+    [roomLight addDelegate:self delegateQueue:dispatch_get_main_queue()];
+    [roomLight activate:streamTest];
+    
+    [streamTest fakeMessageResponse:[self fakeIncomingAffiliationMessage]];
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        NSManagedObjectContext *context = [storage mainThreadManagedObjectContext];
+        NSEntityDescription *entity = [NSEntityDescription entityForName:@"XMPPRoomLightMessageCoreDataStorageObject"
+                                                  inManagedObjectContext:context];
+        
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"roomJIDStr = %@", jid.full];
+        NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"localTimestamp" ascending:YES];
+        
+        NSFetchRequest *request = [[NSFetchRequest alloc] init];
+        request.entity = entity;
+        request.predicate = predicate;
+        request.sortDescriptors = @[sortDescriptor];
+        
+        NSError *error;
+        XMPPRoomLightMessageCoreDataStorageObject *roomMessage = [[context executeFetchRequest:request error:&error] firstObject];
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(roomMessage.jid.full, @"room@domain.com");
+        XCTAssertEqualObjects(roomMessage.body, @"");
+        XCTAssertEqualObjects(roomMessage.nickname, nil);
+        XCTAssertFalse(roomMessage.isFromMe);
+        
+        [expectation fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout:3 handler:^(NSError * _Nullable error) {
+        if(error){
+            XCTFail(@"Expectation Failed with error: %@", error);
+        }
+    }];
+}
+
 - (void)testImportMessage {
     self.checkDelegate = false;
     
@@ -195,6 +244,26 @@
 	NSError *error;
 	NSXMLDocument *doc = [[NSXMLDocument alloc] initWithXMLString:s options:0 error:&error];
 	return [XMPPMessage messageFromElement:[doc rootElement]];
+}
+
+- (XMPPMessage *)fakeIncomingAffiliationMessage{
+    NSMutableString *s = [NSMutableString string];
+    [s appendString: @"<message xmlns='jabber:client' \
+                            from='room@domain.com' \
+                            to='test.user@erlang-solutions.com' \
+                            id='C7A969D8-C711-4516-9313-10EA9927B39B' \
+                            type='groupchat'>"];
+    [s appendString: @"    <body/>"];
+    [s appendString: @"    <x xmlns='urn:xmpp:muclight:0#affiliations'> \
+                                <prev-version>1111111</prev-version> \
+                                <version>aaaaaaa</version> \
+                                <user affiliation='member'>crone1@shakespeare.lit</user> \
+                            </x>"];
+    [s appendString: @"</message>"];
+    
+    NSError *error;
+    NSXMLDocument *doc = [[NSXMLDocument alloc] initWithXMLString:s options:0 error:&error];
+    return [XMPPMessage messageFromElement:[doc rootElement]];
 }
 
 @end


### PR DESCRIPTION
In order to correctly implement last message correction in the context of group messaging, one needs to keep room affiliation change history. This is needed to prevent post-rejoin corrections, as described in the [security considerations](https://xmpp.org/extensions/xep-0308.html#security) section of the XEP.

This pull request adds a MUC Light room module flag that controls whether affiliation change messages are directed to the storage (disabled by default).