### PR TITLE
Add missing id on get archive xml request

### DIFF
--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -352,7 +352,7 @@
 	// </iq>
 	
 	NSXMLElement *pref = [NSXMLElement elementWithName:@"pref" xmlns:XMLNS_XMPP_ARCHIVE];
-	XMPPIQ *iq = [XMPPIQ iqWithType:@"get" to:nil elementID:nil child:pref];
+	XMPPIQ *iq = [XMPPIQ iqWithType:@"get" to:nil elementID:[xmppStream generateUUID] child:pref];
 	
 	[sender sendElement:iq];
 }


### PR DESCRIPTION
The request to get the `archive` from `XMPPMessageArchiving` class missed the id.

Without this `id` the server answers with ```Missing required 'id' attribute```.

Sample response without it:

```
<iq xmlns="jabber:client" type="error"><error type="modify"><bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/><text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">Missing required 'id' attribute</text></error></iq>
```