### PR TITLE
Add missing id on roster add user

### DIFF
--- a/Extensions/Roster/XMPPRoster.m
+++ b/Extensions/Roster/XMPPRoster.m
@@ -516,7 +516,7 @@ enum XMPPRosterFlags
 	[query addChild:item];
 
 	XMPPIQ *iq = [XMPPIQ iqWithType:@"set" child:query];
-	[iq addAttributeWithName:@“id” stringValue:[xmppStream generateUUID]];
+	[iq addAttributeWithName:@"id" stringValue:[xmppStream generateUUID]];
 
 	[xmppStream sendElement:iq];
 

--- a/Extensions/Roster/XMPPRoster.m
+++ b/Extensions/Roster/XMPPRoster.m
@@ -516,6 +516,7 @@ enum XMPPRosterFlags
 	[query addChild:item];
 
 	XMPPIQ *iq = [XMPPIQ iqWithType:@"set" child:query];
+	[iq addAttributeWithName:@“id” stringValue:[xmppStream generateUUID]];
 
 	[xmppStream sendElement:iq];
 


### PR DESCRIPTION
Current generated xml:

```
<iq type="set"><query xmlns="jabber:iq:roster"><item jid="yourjid"/></query></iq>
```

Error response:

```
<iq xmlns="jabber:client" type="error" ><error type="modify"><bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/><text xmlns="urn:ietf:params:xml:ns:xmpp-stanzas">Missing required 'id' attribute</text></error></iq>
```

Check [Instant Messaging and Presence / 2.1.5.  Roster Set](https://xmpp.org/rfcs/rfc6121.html)

