### PR TITLE
Basic one to one chat module implementation

### DIFF
--- a/Core/XMPPFramework.h
+++ b/Core/XMPPFramework.h
@@ -159,6 +159,7 @@
 #import "XMPPRoomLightCoreDataStorage.h"
 #import "XMPPRoomLightCoreDataStorageProtected.h"
 #import "XMPPRoomLightMessageCoreDataStorageObject.h"
+#import "XMPPOneToOneChat.h"
 
 
 FOUNDATION_EXPORT double XMPPFrameworkVersionNumber;

--- a/Extensions/OneToOneChat/XMPPOneToOneChat.h
+++ b/Extensions/OneToOneChat/XMPPOneToOneChat.h
@@ -1,0 +1,27 @@
+#import "XMPPModule.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class XMPPMessage;
+
+/// @brief A module that handles one-to-one chat messaging.
+/// @discussion This module triggers delegate callbacks for all sent or received messages of type 'chat'.
+@interface XMPPOneToOneChat : XMPPModule
+
+@end
+
+/// A protocol defining @c XMPPOneToOneChat module delegate API.
+@protocol XMPPOneToOneChatDelegate <NSObject>
+
+@optional
+/// Notifies the delegate that a chat message has been received in the stream.
+- (void)xmppOneToOneChat:(XMPPOneToOneChat *)xmppOneToOneChat didReceiveChatMessage:(XMPPMessage *)message
+NS_SWIFT_NAME(xmppOneToOneChat(_:didReceiveChatMessage:));
+
+/// Notifies the delegate that a chat message has been sent in the stream.
+- (void)xmppOneToOneChat:(XMPPOneToOneChat *)xmppOneToOneChat didSendChatMessage:(XMPPMessage *)message
+NS_SWIFT_NAME(xmppOneToOneChat(_:didSendChatMessage:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Extensions/OneToOneChat/XMPPOneToOneChat.m
+++ b/Extensions/OneToOneChat/XMPPOneToOneChat.m
@@ -1,0 +1,40 @@
+#import "XMPPOneToOneChat.h"
+#import "XMPPMessage.h"
+#import "XMPPStream.h"
+#import "XMPPLogging.h"
+
+// Log levels: off, error, warn, info, verbose
+// Log flags: trace
+#if DEBUG
+static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN; // | XMPP_LOG_FLAG_TRACE;
+#else
+static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
+#endif
+
+@implementation XMPPOneToOneChat
+
+- (void)xmppStream:(XMPPStream *)sender didReceiveMessage:(XMPPMessage *)message
+{
+    XMPPLogTrace();
+    
+    if (![message isChatMessage]) {
+        return;
+    }
+    
+    XMPPLogInfo(@"Received chat message from %@", [message from]);
+    [multicastDelegate xmppOneToOneChat:self didReceiveChatMessage:message];
+}
+
+- (void)xmppStream:(XMPPStream *)sender didSendMessage:(XMPPMessage *)message
+{
+    XMPPLogTrace();
+    
+    if (![message isChatMessage]) {
+        return;
+    }
+    
+    XMPPLogInfo(@"Sent chat message to %@", [message to]);
+    [multicastDelegate xmppOneToOneChat:self didSendChatMessage:message];
+}
+
+@end

--- a/XMPPFramework.xcodeproj/project.pbxproj
+++ b/XMPPFramework.xcodeproj/project.pbxproj
@@ -923,6 +923,12 @@
 		DD1E733A1ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1E733B1ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1E733C1ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD26F5701F7CD9B500F54F18 /* XMPPOneToOneChat.h in Headers */ = {isa = PBXBuildFile; fileRef = DD26F56E1F7CD9B500F54F18 /* XMPPOneToOneChat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD26F5711F7CD9B500F54F18 /* XMPPOneToOneChat.h in Headers */ = {isa = PBXBuildFile; fileRef = DD26F56E1F7CD9B500F54F18 /* XMPPOneToOneChat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD26F5721F7CD9B500F54F18 /* XMPPOneToOneChat.h in Headers */ = {isa = PBXBuildFile; fileRef = DD26F56E1F7CD9B500F54F18 /* XMPPOneToOneChat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD26F5731F7CD9B500F54F18 /* XMPPOneToOneChat.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F56F1F7CD9B500F54F18 /* XMPPOneToOneChat.m */; };
+		DD26F5741F7CD9B500F54F18 /* XMPPOneToOneChat.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F56F1F7CD9B500F54F18 /* XMPPOneToOneChat.m */; };
+		DD26F5751F7CD9B500F54F18 /* XMPPOneToOneChat.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F56F1F7CD9B500F54F18 /* XMPPOneToOneChat.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1514,6 +1520,8 @@
 		DD1E73311ED885FD009B529B /* XMPPRoomLightCoreDataStorage+XEP_0313.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XMPPRoomLightCoreDataStorage+XEP_0313.h"; sourceTree = "<group>"; };
 		DD1E73321ED885FD009B529B /* XMPPRoomLightCoreDataStorage+XEP_0313.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XMPPRoomLightCoreDataStorage+XEP_0313.m"; sourceTree = "<group>"; };
 		DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPRoomLightCoreDataStorageProtected.h; sourceTree = "<group>"; };
+		DD26F56E1F7CD9B500F54F18 /* XMPPOneToOneChat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XMPPOneToOneChat.h; sourceTree = "<group>"; };
+		DD26F56F1F7CD9B500F54F18 /* XMPPOneToOneChat.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XMPPOneToOneChat.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1757,6 +1765,7 @@
 				D9DCD1431E6250930010D1C7 /* Reconnect */,
 				D9DCD1461E6250930010D1C7 /* Roster */,
 				D9DCD15E1E6250930010D1C7 /* SystemInputActivityMonitor */,
+				DD26F56D1F7CD99100F54F18 /* OneToOneChat */,
 				D9DCD1611E6250930010D1C7 /* XEP-0009 */,
 				D9DCD1681E6250930010D1C7 /* XEP-0012 */,
 				D9DCD16D1E6250930010D1C7 /* XEP-0016 */,
@@ -2533,6 +2542,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		DD26F56D1F7CD99100F54F18 /* OneToOneChat */ = {
+			isa = PBXGroup;
+			children = (
+				DD26F56E1F7CD9B500F54F18 /* XMPPOneToOneChat.h */,
+				DD26F56F1F7CD9B500F54F18 /* XMPPOneToOneChat.m */,
+			);
+			path = OneToOneChat;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -2675,6 +2693,7 @@
 				0D44BB4E1E537105000930E0 /* XMPPDigestMD5Authentication.h in Headers */,
 				0D44BB691E537110000930E0 /* GCDMulticastDelegate.h in Headers */,
 				0D44BB501E537105000930E0 /* XMPPPlainAuthentication.h in Headers */,
+				DD26F5701F7CD9B500F54F18 /* XMPPOneToOneChat.h in Headers */,
 				0D44BB211E5370ED000930E0 /* XMPPStream.h in Headers */,
 				0D44BB1F1E5370ED000930E0 /* XMPPPresence.h in Headers */,
 				0D44BB191E5370ED000930E0 /* XMPPMessage.h in Headers */,
@@ -2836,6 +2855,7 @@
 				D9DCD5191E6256D90010D1C7 /* XMPPDigestMD5Authentication.h in Headers */,
 				D9DCD51A1E6256D90010D1C7 /* GCDMulticastDelegate.h in Headers */,
 				D9DCD51B1E6256D90010D1C7 /* XMPPPlainAuthentication.h in Headers */,
+				DD26F5711F7CD9B500F54F18 /* XMPPOneToOneChat.h in Headers */,
 				D9DCD51C1E6256D90010D1C7 /* XMPPStream.h in Headers */,
 				D9DCD51D1E6256D90010D1C7 /* XMPPPresence.h in Headers */,
 				D9DCD51E1E6256D90010D1C7 /* XMPPMessage.h in Headers */,
@@ -2997,6 +3017,7 @@
 				D9DCD67C1E6258CF0010D1C7 /* XMPPDigestMD5Authentication.h in Headers */,
 				D9DCD67D1E6258CF0010D1C7 /* GCDMulticastDelegate.h in Headers */,
 				D9DCD67E1E6258CF0010D1C7 /* XMPPPlainAuthentication.h in Headers */,
+				DD26F5721F7CD9B500F54F18 /* XMPPOneToOneChat.h in Headers */,
 				D9DCD67F1E6258CF0010D1C7 /* XMPPStream.h in Headers */,
 				D9DCD6801E6258CF0010D1C7 /* XMPPPresence.h in Headers */,
 				D9DCD6811E6258CF0010D1C7 /* XMPPMessage.h in Headers */,
@@ -3403,6 +3424,7 @@
 				0D44BB221E5370ED000930E0 /* XMPPStream.m in Sources */,
 				D9DCD2BD1E6250930010D1C7 /* XMPPvCardTempBase.m in Sources */,
 				0D44BB4D1E537105000930E0 /* XMPPDeprecatedPlainAuthentication.m in Sources */,
+				DD26F5731F7CD9B500F54F18 /* XMPPOneToOneChat.m in Sources */,
 				D9DCD3171E6250930010D1C7 /* XMPPMessage+XEP_0224.m in Sources */,
 				D9DCD2E41E6250930010D1C7 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
 				0D44BB511E537105000930E0 /* XMPPPlainAuthentication.m in Sources */,
@@ -3555,6 +3577,7 @@
 				D9DCD4271E6256D90010D1C7 /* XMPPStream.m in Sources */,
 				D9DCD4281E6256D90010D1C7 /* XMPPvCardTempBase.m in Sources */,
 				D9DCD4291E6256D90010D1C7 /* XMPPDeprecatedPlainAuthentication.m in Sources */,
+				DD26F5741F7CD9B500F54F18 /* XMPPOneToOneChat.m in Sources */,
 				D9DCD42A1E6256D90010D1C7 /* XMPPMessage+XEP_0224.m in Sources */,
 				D9DCD42B1E6256D90010D1C7 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
 				D9DCD42C1E6256D90010D1C7 /* XMPPPlainAuthentication.m in Sources */,
@@ -3707,6 +3730,7 @@
 				D9DCD58A1E6258CF0010D1C7 /* XMPPStream.m in Sources */,
 				D9DCD58B1E6258CF0010D1C7 /* XMPPvCardTempBase.m in Sources */,
 				D9DCD58C1E6258CF0010D1C7 /* XMPPDeprecatedPlainAuthentication.m in Sources */,
+				DD26F5751F7CD9B500F54F18 /* XMPPOneToOneChat.m in Sources */,
 				D9DCD58D1E6258CF0010D1C7 /* XMPPMessage+XEP_0224.m in Sources */,
 				D9DCD58E1E6258CF0010D1C7 /* XMPPCapabilitiesCoreDataStorage.m in Sources */,
 				D9DCD58F1E6258CF0010D1C7 /* XMPPPlainAuthentication.m in Sources */,

--- a/Xcode/Testing-Carthage/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-Carthage/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		D9DCD70E1E625C560010D1C7 /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9DCD7191E625CAE0010D1C7 /* XMPPFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9DCD6B01E625A9B0010D1C7 /* XMPPFramework.framework */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
+		DD26F5881F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F5871F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m */; };
+		DD26F5891F7CF1B400F54F18 /* XMPPOneToOneChatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F5871F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m */; };
+		DD26F58A1F7CF1B400F54F18 /* XMPPOneToOneChatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F5871F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,6 +136,7 @@
 		D9DCD3EC1E6255E10010D1C7 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9DCD7151E625C560010D1C7 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../Testing-Shared/OMEMOElementTests.m"; sourceTree = SOURCE_ROOT; };
+		DD26F5871F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPOneToOneChatTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -202,6 +206,7 @@
 				D973A0791D2F18040096F3ED /* XMPPStorageHintTests.m */,
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
+				DD26F5871F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 			);
 			name = XMPPFrameworkTests;
@@ -385,6 +390,7 @@
 				D973A07D1D2F18040096F3ED /* EncodeDecodeTest.m in Sources */,
 				D973A0831D2F18040096F3ED /* XMPPRoomLightCoreDataStorageTests.m in Sources */,
 				D973A0801D2F18040096F3ED /* XMPPMockStream.m in Sources */,
+				DD26F5881F7CF1AE00F54F18 /* XMPPOneToOneChatTests.m in Sources */,
 				D973A0841D2F18040096F3ED /* XMPPRoomLightTests.m in Sources */,
 				D97509281D9C82DB002E6F51 /* OMEMOServerTests.m in Sources */,
 				D99C5E0D1D99C48100FB068A /* OMEMOModuleTests.m in Sources */,
@@ -409,6 +415,7 @@
 				D9DCD3D71E6255E10010D1C7 /* EncodeDecodeTest.m in Sources */,
 				D9DCD3D81E6255E10010D1C7 /* XMPPRoomLightCoreDataStorageTests.m in Sources */,
 				D9DCD3D91E6255E10010D1C7 /* XMPPMockStream.m in Sources */,
+				DD26F5891F7CF1B400F54F18 /* XMPPOneToOneChatTests.m in Sources */,
 				D9DCD3DA1E6255E10010D1C7 /* XMPPRoomLightTests.m in Sources */,
 				D9DCD3DB1E6255E10010D1C7 /* OMEMOServerTests.m in Sources */,
 				D9DCD3DC1E6255E10010D1C7 /* OMEMOModuleTests.m in Sources */,
@@ -433,6 +440,7 @@
 				D9DCD7001E625C560010D1C7 /* EncodeDecodeTest.m in Sources */,
 				D9DCD7011E625C560010D1C7 /* XMPPRoomLightCoreDataStorageTests.m in Sources */,
 				D9DCD7021E625C560010D1C7 /* XMPPMockStream.m in Sources */,
+				DD26F58A1F7CF1B400F54F18 /* XMPPOneToOneChatTests.m in Sources */,
 				D9DCD7031E625C560010D1C7 /* XMPPRoomLightTests.m in Sources */,
 				D9DCD7041E625C560010D1C7 /* OMEMOServerTests.m in Sources */,
 				D9DCD7051E625C560010D1C7 /* OMEMOModuleTests.m in Sources */,

--- a/Xcode/Testing-Shared/XMPPOneToOneChatTests.m
+++ b/Xcode/Testing-Shared/XMPPOneToOneChatTests.m
@@ -1,0 +1,76 @@
+#import <XCTest/XCTest.h>
+#import "XMPPMockStream.h"
+
+@interface XMPPOneToOneChatTests : XCTestCase <XMPPOneToOneChatDelegate>
+
+@property (nonatomic, strong) XMPPMockStream *mockStream;
+@property (nonatomic, strong) XMPPOneToOneChat *oneToOneChat;
+@property (nonatomic, strong) XCTestExpectation *delegateCallbackExpectation;
+
+@end
+
+@implementation XMPPOneToOneChatTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.mockStream = [[XMPPMockStream alloc] init];
+    self.oneToOneChat = [[XMPPOneToOneChat alloc] init];
+    [self.oneToOneChat addDelegate:self delegateQueue:dispatch_get_main_queue()];
+    [self.oneToOneChat activate:self.mockStream];
+}
+
+- (void)testIncomingMessageHandling
+{
+    self.delegateCallbackExpectation = [self expectationWithDescription:@"Incoming message delegate callback expectation"];
+    
+    XMPPMessage *chatMessage = [[XMPPMessage alloc] initWithXMLString:
+                                @"<message from='juliet@example.com'"
+                                @"         to='romeo@example.net'"
+                                @"         type='chat'>"
+                                @"  <body>Art thou not Romeo, and a Montague?</body>"
+                                @"</message>"
+                                                                error:nil];
+    
+    XMPPMessage *emptyMessage = [[XMPPMessage alloc] initWithXMLString:
+                                 @"<message from='juliet@example.com' to='romeo@example.net'/>"
+                                                                 error:nil];
+    
+    [self.mockStream fakeMessageResponse:chatMessage];
+    [self.mockStream fakeMessageResponse:emptyMessage];
+    
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+- (void)testOutgoingMessageHandling
+{
+    self.delegateCallbackExpectation = [self expectationWithDescription:@"Sent message delegate callback expectation"];
+    
+    XMPPMessage *chatMessage = [[XMPPMessage alloc] initWithXMLString:
+                                @"<message to='romeo@example.net'"
+                                @"         type='chat'>"
+                                @"  <body>Art thou not Romeo, and a Montague?</body>"
+                                @"</message>"
+                                                                error:nil];
+    
+    XMPPMessage *emptyMessage = [[XMPPMessage alloc] initWithXMLString:
+                                 @"<message to='romeo@example.net'/>"
+                                                                 error:nil];
+    
+    [self.mockStream sendElement:chatMessage];
+    [self.mockStream sendElement:emptyMessage];
+    
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+- (void)xmppOneToOneChat:(XMPPOneToOneChat *)xmppOneToOneChat didReceiveChatMessage:(XMPPMessage *)message
+{
+    [self.delegateCallbackExpectation fulfill];
+}
+
+- (void)xmppOneToOneChat:(XMPPOneToOneChat *)xmppOneToOneChat didSendChatMessage:(XMPPMessage *)message
+{
+    [self.delegateCallbackExpectation fulfill];
+}
+
+@end

--- a/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D99C5E0E1D99C48100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
 		DD1E732C1ED86B7D009B529B /* XMPPPubSubTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */; };
+		DD26F5831F7CECD100F54F18 /* XMPPOneToOneChatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F5821F7CECD100F54F18 /* XMPPOneToOneChatTests.m */; };
 		FDD2AB232C05507F2045FFFC /* Pods_XMPPFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD0B17267211A912DE2098E /* Pods_XMPPFrameworkTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +56,7 @@
 		D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
 		DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPubSubTests.m; path = "../../Testing-Shared/XMPPPubSubTests.m"; sourceTree = "<group>"; };
+		DD26F5821F7CECD100F54F18 /* XMPPOneToOneChatTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = XMPPOneToOneChatTests.m; path = "../../Testing-Shared/XMPPOneToOneChatTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
 				DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */,
+				DD26F5821F7CECD100F54F18 /* XMPPOneToOneChatTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 				D973A06E1D2F18030096F3ED /* XMPPFrameworkTests-Bridging-Header.h */,
 			);
@@ -251,6 +254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D973A07C1D2F18040096F3ED /* CapabilitiesHashingTest.m in Sources */,
+				DD26F5831F7CECD100F54F18 /* XMPPOneToOneChatTests.m in Sources */,
 				D973A0811D2F18040096F3ED /* XMPPMUCLightTests.m in Sources */,
 				D973A07D1D2F18040096F3ED /* EncodeDecodeTest.m in Sources */,
 				D973A0831D2F18040096F3ED /* XMPPRoomLightCoreDataStorageTests.m in Sources */,

--- a/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D99C5E091D95EBA100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E081D95EBA100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E6E1D90B2C5002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6D1D90B2C5002E7CF7 /* OMEMOElementTests.m */; };
 		D9F20D011D836080002A8D6F /* OMEMOModuleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9F20D001D836080002A8D6F /* OMEMOModuleTests.m */; };
+		DD26F5851F7CF17200F54F18 /* XMPPOneToOneChatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD26F5841F7CF17200F54F18 /* XMPPOneToOneChatTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		D99C5E081D95EBA100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6D1D90B2C5002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
 		D9F20D001D836080002A8D6F /* OMEMOModuleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOModuleTests.m; path = "../../Testing-Shared/OMEMOModuleTests.m"; sourceTree = "<group>"; };
+		DD26F5841F7CF17200F54F18 /* XMPPOneToOneChatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPOneToOneChatTests.m; path = "../../Testing-Shared/XMPPOneToOneChatTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				D973A0A11D2F1EF60096F3ED /* XMPPSwift.swift */,
 				D973A0A21D2F1EF60096F3ED /* XMPPURITests.m */,
 				D973A0A31D2F1EF60096F3ED /* XMPPvCardTests.m */,
+				DD26F5841F7CF17200F54F18 /* XMPPOneToOneChatTests.m */,
 				D973A0921D2F1EB10096F3ED /* Info.plist */,
 			);
 			path = XMPPFrameworkTests;
@@ -258,6 +261,7 @@
 				D973A0B01D2F1EF60096F3ED /* XMPPvCardTests.m in Sources */,
 				D973A0A71D2F1EF60096F3ED /* XMPPMessageArchiveManagementTests.m in Sources */,
 				D9E35E6E1D90B2C5002E7CF7 /* OMEMOElementTests.m in Sources */,
+				DD26F5851F7CF17200F54F18 /* XMPPOneToOneChatTests.m in Sources */,
 				D973A0A61D2F1EF60096F3ED /* XMPPHTTPFileUploadTests.m in Sources */,
 				D973A0AA1D2F1EF60096F3ED /* XMPPPushTests.swift in Sources */,
 				D973A0AD1D2F1EF60096F3ED /* XMPPStorageHintTests.m in Sources */,


### PR DESCRIPTION
This pull request implements private chat handling module, one of the modules described in the "Currently supported XMPP extensions" section in #993.
Storage helpers implementation is not yet included here, as it depends on both #996 and #997.