### PR TITLE
Fix MUC Light affiliation change handling

### DIFF
--- a/Extensions/XMPPMUCLight/XMPPMUCLight.h
+++ b/Extensions/XMPPMUCLight/XMPPMUCLight.h
@@ -53,7 +53,7 @@
 
 - (void)xmppMUCLight:(nonnull XMPPMUCLight *)sender didDiscoverRooms:(nonnull NSArray<__kindof NSXMLElement*>*)rooms forServiceNamed:(nonnull NSString *)serviceName;
 - (void)xmppMUCLight:(nonnull XMPPMUCLight *)sender failedToDiscoverRoomsForServiceNamed:(nonnull NSString *)serviceName withError:(nonnull NSError *)error;
-- (void)xmppMUCLight:(nonnull XMPPMUCLight *)sender changedAffiliation:(nonnull NSString *)affiliation roomJID:(nonnull XMPPJID *)roomJID;
+- (void)xmppMUCLight:(nonnull XMPPMUCLight *)sender changedAffiliation:(nonnull NSString *)affiliation userJID:(nonnull XMPPJID *)userJID roomJID:(nonnull XMPPJID *)roomJID;
 
 - (void)xmppMUCLight:(nonnull XMPPMUCLight *)sender didRequestBlockingList:(nonnull NSArray<NSXMLElement*>*)items forServiceNamed:(nonnull NSString *)serviceName;
 - (void)xmppMUCLight:(nonnull XMPPMUCLight *)sender failedToRequestBlockingList:(nonnull NSString *)serviceName withError:(nonnull XMPPIQ *)iq;

--- a/Extensions/XMPPMUCLight/XMPPMUCLight.m
+++ b/Extensions/XMPPMUCLight/XMPPMUCLight.m
@@ -241,12 +241,11 @@ NSString *const XMPPMUCLightBlocking = @"urn:xmpp:muclight:0#blocking";
 
 	XMPPJID *from = message.from;
 	NSXMLElement *x = [message elementForName:@"x" xmlns:XMPPRoomLightAffiliations];
-	NSXMLElement *user  = [x elementForName:@"user"];
-	NSString *affiliation = [user attributeForName:@"affiliation"].stringValue;
-
-	if (affiliation) {
-		[multicastDelegate xmppMUCLight:self changedAffiliation:affiliation roomJID:from];
-	}
+    for (NSXMLElement *user in [x elementsForName:@"user"]) {
+        NSString *affiliation = [user attributeForName:@"affiliation"].stringValue;
+        XMPPJID *userJID = [XMPPJID jidWithString:user.stringValue];
+        [multicastDelegate xmppMUCLight:self changedAffiliation:affiliation userJID:userJID roomJID:from];
+    }
 }
 
 - (void)xmppStream:(XMPPStream *)sender didRegisterModule:(id)module {

--- a/Xcode/Testing-Shared/XMPPMUCLightTests.m
+++ b/Xcode/Testing-Shared/XMPPMUCLightTests.m
@@ -263,7 +263,7 @@
 	}];
 }
 
-- (void)xmppMUCLight:(XMPPMUCLight *)sender changedAffiliation:(NSString *)affiliation roomJID:(XMPPJID *)roomJID {
+- (void)xmppMUCLight:(XMPPMUCLight *)sender changedAffiliation:(NSString *)affiliation userJID:(XMPPJID *)userJID roomJID:(XMPPJID *)roomJID {
 	XCTAssertEqualObjects(affiliation, @"member");
 	XCTAssertEqualObjects(roomJID.full, @"coven@muclight.shakespeare.lit");
 	[self.delegateResponseExpectation fulfill];


### PR DESCRIPTION
This pull requests fixes the following issues in MUC Light `-xmppMUCLight:changedAffiliation:roomJID:` callback: 
* The callback was only invoked once per incoming affiliation change message even if the server reported changes for several occupants.
* The callback didn't include the JID of the occupant whose affiliation changed

The above fix is a prerequisite to introduce the last message correction handling module, one of the modules mentioned in the "Currently supported XMPP extensions" section in #993.

Technically, this pull request breaks `XMPPMUCLightDelegate` API. There are some good reasons to do so though:
* MUC Light may still be considered as having "semi-experimental" status
* The callback in its old form could misguide application developers leading to bugs where some affiliation changes go undetected