### PR TITLE
Receipt response processing in XMPPMessageDeliveryReceipts

### DIFF
--- a/Extensions/XEP-0184/XMPPMessageDeliveryReceipts.h
+++ b/Extensions/XEP-0184/XMPPMessageDeliveryReceipts.h
@@ -2,6 +2,8 @@
 
 #define _XMPP_MESSAGE_DELIVERY_RECEIPTS_H
 
+@class XMPPMessage;
+
 /**
  * XMPPMessageDeliveryReceipts can be configured to automatically send delivery receipts and requests in accordance to XEP-0184
 **/
@@ -29,6 +31,20 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 
 @property (assign) BOOL autoSendMessageDeliveryReceipts;
+
+@end
+
+/**
+ * A protocol defining @c XMPPManagedMessaging module delegate API.
+**/
+@protocol XMPPMessageDeliveryReceiptsDelegate <NSObject>
+
+@optional
+
+/**
+ * Notifies the delegate of a receipt response message received in the stream.
+**/
+- (void)xmppMessageDeliveryReceipts:(XMPPMessageDeliveryReceipts *)xmppMessageDeliveryReceipts didReceiveReceiptResponseMessage:(XMPPMessage *)message;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Extensions/XEP-0184/XMPPMessageDeliveryReceipts.m
+++ b/Extensions/XEP-0184/XMPPMessageDeliveryReceipts.m
@@ -129,6 +129,11 @@
             [sender sendElement:generatedReceiptResponse];
         }
     }
+    
+    if ([message hasReceiptResponse])
+    {
+        [multicastDelegate xmppMessageDeliveryReceipts:self didReceiveReceiptResponseMessage:message];
+    }
 }
 
 - (XMPPMessage *)xmppStream:(XMPPStream *)sender willSendMessage:(XMPPMessage *)message

--- a/Xcode/Testing-Carthage/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-Carthage/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		D9DCD70E1E625C560010D1C7 /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9DCD7191E625CAE0010D1C7 /* XMPPFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9DCD6B01E625A9B0010D1C7 /* XMPPFramework.framework */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
+		DD06EA451F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD06EA441F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */; };
+		DD06EA461F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD06EA441F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */; };
+		DD06EA471F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD06EA441F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,6 +136,7 @@
 		D9DCD3EC1E6255E10010D1C7 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9DCD7151E625C560010D1C7 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../Testing-Shared/OMEMOElementTests.m"; sourceTree = SOURCE_ROOT; };
+		DD06EA441F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPMessageDeliveryReceiptsTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -202,6 +206,7 @@
 				D973A0791D2F18040096F3ED /* XMPPStorageHintTests.m */,
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
+				DD06EA441F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 			);
 			name = XMPPFrameworkTests;
@@ -387,6 +392,7 @@
 				D973A0801D2F18040096F3ED /* XMPPMockStream.m in Sources */,
 				D973A0841D2F18040096F3ED /* XMPPRoomLightTests.m in Sources */,
 				D97509281D9C82DB002E6F51 /* OMEMOServerTests.m in Sources */,
+				DD06EA451F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */,
 				D99C5E0D1D99C48100FB068A /* OMEMOModuleTests.m in Sources */,
 				D973A0861D2F18040096F3ED /* XMPPURITests.m in Sources */,
 				D973A07F1D2F18040096F3ED /* XMPPMessageArchiveManagementTests.m in Sources */,
@@ -411,6 +417,7 @@
 				D9DCD3D91E6255E10010D1C7 /* XMPPMockStream.m in Sources */,
 				D9DCD3DA1E6255E10010D1C7 /* XMPPRoomLightTests.m in Sources */,
 				D9DCD3DB1E6255E10010D1C7 /* OMEMOServerTests.m in Sources */,
+				DD06EA461F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */,
 				D9DCD3DC1E6255E10010D1C7 /* OMEMOModuleTests.m in Sources */,
 				D9DCD3DD1E6255E10010D1C7 /* XMPPURITests.m in Sources */,
 				D9DCD3DE1E6255E10010D1C7 /* XMPPMessageArchiveManagementTests.m in Sources */,
@@ -435,6 +442,7 @@
 				D9DCD7021E625C560010D1C7 /* XMPPMockStream.m in Sources */,
 				D9DCD7031E625C560010D1C7 /* XMPPRoomLightTests.m in Sources */,
 				D9DCD7041E625C560010D1C7 /* OMEMOServerTests.m in Sources */,
+				DD06EA471F78EBFD008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */,
 				D9DCD7051E625C560010D1C7 /* OMEMOModuleTests.m in Sources */,
 				D9DCD7061E625C560010D1C7 /* XMPPURITests.m in Sources */,
 				D9DCD7071E625C560010D1C7 /* XMPPMessageArchiveManagementTests.m in Sources */,

--- a/Xcode/Testing-Shared/XMPPMessageDeliveryReceiptsTests.m
+++ b/Xcode/Testing-Shared/XMPPMessageDeliveryReceiptsTests.m
@@ -1,0 +1,47 @@
+#import <XCTest/XCTest.h>
+#import "XMPPMockStream.h"
+
+@interface XMPPMessageDeliveryReceiptsTests : XCTestCase <XMPPMessageDeliveryReceiptsDelegate>
+
+@property (strong, nonatomic) XMPPMockStream *mockStream;
+@property (strong, nonatomic) XMPPMessageDeliveryReceipts *messageDeliveryReceipts;
+@property (strong, nonatomic) XCTestExpectation *delegateCallbackExpectation;
+
+@end
+
+@implementation XMPPMessageDeliveryReceiptsTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.mockStream = [[XMPPMockStream alloc] init];
+    self.messageDeliveryReceipts = [[XMPPMessageDeliveryReceipts alloc] init];
+    [self.messageDeliveryReceipts addDelegate:self delegateQueue:dispatch_get_main_queue()];
+    [self.messageDeliveryReceipts activate:self.mockStream];
+}
+
+- (void)testReceiptResponseDelegateCallback
+{
+    self.delegateCallbackExpectation = [self expectationWithDescription:@"Delegate callback expectation"];
+    
+    [self.mockStream fakeMessageResponse:
+     [[XMPPMessage alloc] initWithXMLString:
+      @"<message"
+      @"    from='kingrichard@royalty.england.lit/throne'"
+      @"    id='bi29sg183b4v'"
+      @"    to='northumberland@shakespeare.lit/westminster'>"
+      @"  <received xmlns='urn:xmpp:receipts' id='richard2-4.1.247'/>"
+      @"</message>"
+                                      error:nil]];
+    
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+- (void)xmppMessageDeliveryReceipts:(XMPPMessageDeliveryReceipts *)xmppMessageDeliveryReceipts didReceiveReceiptResponseMessage:(XMPPMessage *)message
+{
+    if ([message hasReceiptResponse]) {
+        [self.delegateCallbackExpectation fulfill];
+    }
+}
+
+@end

--- a/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D99C5E0D1D99C48100FB068A /* OMEMOModuleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0A1D99C48100FB068A /* OMEMOModuleTests.m */; };
 		D99C5E0E1D99C48100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
+		DD06EA401F78E566008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD06EA3F1F78E566008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */; };
 		DD1E732C1ED86B7D009B529B /* XMPPPubSubTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */; };
 		FDD2AB232C05507F2045FFFC /* Pods_XMPPFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD0B17267211A912DE2098E /* Pods_XMPPFrameworkTests.framework */; };
 /* End PBXBuildFile section */
@@ -54,6 +55,7 @@
 		D99C5E0B1D99C48100FB068A /* OMEMOTestStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OMEMOTestStorage.h; path = "../../Testing-Shared/OMEMOTestStorage.h"; sourceTree = "<group>"; };
 		D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
+		DD06EA3F1F78E566008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = XMPPMessageDeliveryReceiptsTests.m; path = "../../Testing-Shared/XMPPMessageDeliveryReceiptsTests.m"; sourceTree = "<group>"; };
 		DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPubSubTests.m; path = "../../Testing-Shared/XMPPPubSubTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -108,6 +110,7 @@
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
 				DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */,
+				DD06EA3F1F78E566008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 				D973A06E1D2F18030096F3ED /* XMPPFrameworkTests-Bridging-Header.h */,
 			);
@@ -266,6 +269,7 @@
 				D973A0851D2F18040096F3ED /* XMPPStorageHintTests.m in Sources */,
 				D973A0891D2F18310096F3ED /* XMPPSwift.swift in Sources */,
 				DD1E732C1ED86B7D009B529B /* XMPPPubSubTests.m in Sources */,
+				DD06EA401F78E566008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */,
 				D973A0871D2F18040096F3ED /* XMPPvCardTests.m in Sources */,
 				D99C5E0E1D99C48100FB068A /* OMEMOTestStorage.m in Sources */,
 			);

--- a/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D99C5E091D95EBA100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E081D95EBA100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E6E1D90B2C5002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6D1D90B2C5002E7CF7 /* OMEMOElementTests.m */; };
 		D9F20D011D836080002A8D6F /* OMEMOModuleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9F20D001D836080002A8D6F /* OMEMOModuleTests.m */; };
+		DD06EA421F78EB3B008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD06EA411F78EB3B008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		D99C5E081D95EBA100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6D1D90B2C5002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
 		D9F20D001D836080002A8D6F /* OMEMOModuleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOModuleTests.m; path = "../../Testing-Shared/OMEMOModuleTests.m"; sourceTree = "<group>"; };
+		DD06EA411F78EB3B008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPMessageDeliveryReceiptsTests.m; path = "../../Testing-Shared/XMPPMessageDeliveryReceiptsTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				D973A0A11D2F1EF60096F3ED /* XMPPSwift.swift */,
 				D973A0A21D2F1EF60096F3ED /* XMPPURITests.m */,
 				D973A0A31D2F1EF60096F3ED /* XMPPvCardTests.m */,
+				DD06EA411F78EB3B008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m */,
 				D973A0921D2F1EB10096F3ED /* Info.plist */,
 			);
 			path = XMPPFrameworkTests;
@@ -246,6 +249,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D973A0A41D2F1EF60096F3ED /* CapabilitiesHashingTest.m in Sources */,
+				DD06EA421F78EB3B008FA8C2 /* XMPPMessageDeliveryReceiptsTests.m in Sources */,
 				D9F20D011D836080002A8D6F /* OMEMOModuleTests.m in Sources */,
 				D973A0A91D2F1EF60096F3ED /* XMPPMUCLightTests.m in Sources */,
 				D973A0A51D2F1EF60096F3ED /* EncodeDecodeTest.m in Sources */,


### PR DESCRIPTION
This pull request implements XEP-0184 receipt response processing. It is intended to be followed up by the XMPPMessageCoreDataStorage helper implementation pull request once #996 and #997 are merged.