### PR TITLE
Out of band data URI message handling module

### DIFF
--- a/Core/XMPPFramework.h
+++ b/Core/XMPPFramework.h
@@ -105,6 +105,7 @@
 #import "TURNSocket.h"
 #import "XMPPIQ+XEP_0066.h"
 #import "XMPPMessage+XEP_0066.h"
+#import "XMPPOutOfBandResourceMessaging.h"
 #import "XMPPRegistration.h"
 #import "NSDate+XMPPDateTimeProfiles.h"
 #import "XMPPDateTimeProfiles.h"

--- a/Extensions/XEP-0066/XMPPOutOfBandResourceMessaging.h
+++ b/Extensions/XEP-0066/XMPPOutOfBandResourceMessaging.h
@@ -1,0 +1,28 @@
+#import "XMPPModule.h"
+
+@class XMPPMessage;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A module that handles incoming XEP-0066 Out of Band Data URI messages.
+@interface XMPPOutOfBandResourceMessaging : XMPPModule
+
+/// @brief The set of URL schemes handled by the module.
+/// @discussion If set to @c nil (the default), URL filtering is disabled.
+@property (copy, nullable) NSSet<NSString *> *relevantURLSchemes;
+
+@end
+
+/// A protocol defining @c XMPPOutOfBandResourceMessagingDelegate module delegate API.
+@protocol XMPPOutOfBandResourceMessagingDelegate <NSObject>
+
+@optional
+
+/// Notifies the delegate that a message containing a relevant XEP-0066 Out of Band Data URI has been received in the stream.
+- (void)xmppOutOfBandResourceMessaging:(XMPPOutOfBandResourceMessaging *)xmppOutOfBandResourceMessaging
+    didReceiveOutOfBandResourceMessage:(XMPPMessage *)message
+NS_SWIFT_NAME(xmppOutOfBandResourceMessaging(_:didReceiveOutOfBandResourceMessage:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Extensions/XEP-0066/XMPPOutOfBandResourceMessaging.m
+++ b/Extensions/XEP-0066/XMPPOutOfBandResourceMessaging.m
@@ -1,0 +1,76 @@
+#import "XMPPOutOfBandResourceMessaging.h"
+#import "XMPPMessage+XEP_0066.h"
+#import "XMPPStream.h"
+#import "XMPPLogging.h"
+
+// Log levels: off, error, warn, info, verbose
+// Log flags: trace
+#if DEBUG
+static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN; // | XMPP_LOG_FLAG_TRACE;
+#else
+static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
+#endif
+
+@implementation XMPPOutOfBandResourceMessaging
+
+@synthesize relevantURLSchemes = _relevantURLSchemes;
+
+- (NSSet<NSString *> *)relevantURLSchemes
+{
+    __block NSSet *result;
+    dispatch_block_t block = ^{
+        result = _relevantURLSchemes;
+    };
+    
+    if (dispatch_get_specific(moduleQueueTag))
+        block();
+    else
+        dispatch_sync(moduleQueue, block);
+    
+    return result;
+}
+
+- (void)setRelevantURLSchemes:(NSSet<NSString *> *)relevantURLSchemes
+{
+    NSSet *newValue = [relevantURLSchemes copy];
+    dispatch_block_t block = ^{
+        _relevantURLSchemes = newValue;
+    };
+    
+    if (dispatch_get_specific(moduleQueueTag))
+        block();
+    else
+        dispatch_async(moduleQueue, block);
+}
+
+- (void)didActivate
+{
+    XMPPLogTrace();
+}
+
+- (void)willDeactivate
+{
+    XMPPLogTrace();
+}
+
+- (void)xmppStream:(XMPPStream *)sender didReceiveMessage:(XMPPMessage *)message
+{
+    XMPPLogTrace();
+    
+    if (![message hasOutOfBandData]) {
+        return;
+    }
+    
+    NSString *resourceURIString = [message outOfBandURI];
+    if (self.relevantURLSchemes) {
+        NSURL *resourceURL = [NSURL URLWithString:resourceURIString];
+        if (!resourceURL.scheme || ![self.relevantURLSchemes containsObject:resourceURL.scheme]) {
+            return;
+        }
+    }
+    
+    XMPPLogInfo(@"Received out of band resource message");
+    [multicastDelegate xmppOutOfBandResourceMessaging:self didReceiveOutOfBandResourceMessage:message];
+}
+
+@end

--- a/XMPPFramework.xcodeproj/project.pbxproj
+++ b/XMPPFramework.xcodeproj/project.pbxproj
@@ -923,6 +923,12 @@
 		DD1E733A1ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1E733B1ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DD1E733C1ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD855F911F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = DD855F8F1F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD855F921F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = DD855F8F1F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD855F931F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h in Headers */ = {isa = PBXBuildFile; fileRef = DD855F8F1F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD855F941F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m in Sources */ = {isa = PBXBuildFile; fileRef = DD855F901F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m */; };
+		DD855F951F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m in Sources */ = {isa = PBXBuildFile; fileRef = DD855F901F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m */; };
+		DD855F961F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m in Sources */ = {isa = PBXBuildFile; fileRef = DD855F901F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1514,6 +1520,8 @@
 		DD1E73311ED885FD009B529B /* XMPPRoomLightCoreDataStorage+XEP_0313.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XMPPRoomLightCoreDataStorage+XEP_0313.h"; sourceTree = "<group>"; };
 		DD1E73321ED885FD009B529B /* XMPPRoomLightCoreDataStorage+XEP_0313.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XMPPRoomLightCoreDataStorage+XEP_0313.m"; sourceTree = "<group>"; };
 		DD1E73391ED88622009B529B /* XMPPRoomLightCoreDataStorageProtected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XMPPRoomLightCoreDataStorageProtected.h; sourceTree = "<group>"; };
+		DD855F8F1F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XMPPOutOfBandResourceMessaging.h; sourceTree = "<group>"; };
+		DD855F901F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XMPPOutOfBandResourceMessaging.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2107,6 +2115,8 @@
 				D9DCD1BF1E6250930010D1C7 /* XMPPIQ+XEP_0066.m */,
 				D9DCD1C01E6250930010D1C7 /* XMPPMessage+XEP_0066.h */,
 				D9DCD1C11E6250930010D1C7 /* XMPPMessage+XEP_0066.m */,
+				DD855F8F1F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h */,
+				DD855F901F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m */,
 			);
 			path = "XEP-0066";
 			sourceTree = "<group>";
@@ -2552,6 +2562,7 @@
 				0D44BB4A1E537105000930E0 /* XMPPDeprecatedDigestAuthentication.h in Headers */,
 				D9DCD3261E6250930010D1C7 /* NSXMLElement+XEP_0335.h in Headers */,
 				D9DCD2A41E6250930010D1C7 /* XMPPMessage+XEP0045.h in Headers */,
+				DD855F911F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h in Headers */,
 				D9DCD2EE1E6250930010D1C7 /* XMPPMessageArchiving_Message_CoreDataObject.h in Headers */,
 				D9DCD2791E6250930010D1C7 /* XMPPRosterMemoryStoragePrivate.h in Headers */,
 				D9DCD3241E6250930010D1C7 /* XMPPMessage+XEP_0334.h in Headers */,
@@ -2713,6 +2724,7 @@
 				D9DCD4A01E6256D90010D1C7 /* XMPPDeprecatedDigestAuthentication.h in Headers */,
 				D9DCD4A11E6256D90010D1C7 /* NSXMLElement+XEP_0335.h in Headers */,
 				D9DCD4A21E6256D90010D1C7 /* XMPPMessage+XEP0045.h in Headers */,
+				DD855F921F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h in Headers */,
 				D9DCD4A31E6256D90010D1C7 /* XMPPMessageArchiving_Message_CoreDataObject.h in Headers */,
 				D9DCD4A41E6256D90010D1C7 /* XMPPRosterMemoryStoragePrivate.h in Headers */,
 				D9DCD4A51E6256D90010D1C7 /* XMPPMessage+XEP_0334.h in Headers */,
@@ -2874,6 +2886,7 @@
 				D9DCD6031E6258CF0010D1C7 /* XMPPDeprecatedDigestAuthentication.h in Headers */,
 				D9DCD6041E6258CF0010D1C7 /* NSXMLElement+XEP_0335.h in Headers */,
 				D9DCD6051E6258CF0010D1C7 /* XMPPMessage+XEP0045.h in Headers */,
+				DD855F931F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.h in Headers */,
 				D9DCD6061E6258CF0010D1C7 /* XMPPMessageArchiving_Message_CoreDataObject.h in Headers */,
 				D9DCD6071E6258CF0010D1C7 /* XMPPRosterMemoryStoragePrivate.h in Headers */,
 				D9DCD6081E6258CF0010D1C7 /* XMPPMessage+XEP_0334.h in Headers */,
@@ -3455,6 +3468,7 @@
 				D9DCD2531E6250930010D1C7 /* XMPPIncomingFileTransfer.m in Sources */,
 				0D44BB531E537105000930E0 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				D9DCD32B1E6250930010D1C7 /* XMPPIQ+XEP_0357.m in Sources */,
+				DD855F941F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m in Sources */,
 				D9DCD2F71E6250930010D1C7 /* XMPPvCardAvatarModule.m in Sources */,
 				D9DCD26B1E6250930010D1C7 /* XMPPReconnect.m in Sources */,
 				D9DCD2B91E6250930010D1C7 /* XMPPvCardTempAdr.m in Sources */,
@@ -3607,6 +3621,7 @@
 				D9DCD45B1E6256D90010D1C7 /* XMPPIncomingFileTransfer.m in Sources */,
 				D9DCD45C1E6256D90010D1C7 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				D9DCD45D1E6256D90010D1C7 /* XMPPIQ+XEP_0357.m in Sources */,
+				DD855F951F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m in Sources */,
 				D9DCD45E1E6256D90010D1C7 /* XMPPvCardAvatarModule.m in Sources */,
 				D9DCD45F1E6256D90010D1C7 /* XMPPReconnect.m in Sources */,
 				D9DCD4601E6256D90010D1C7 /* XMPPvCardTempAdr.m in Sources */,
@@ -3759,6 +3774,7 @@
 				D9DCD5BE1E6258CF0010D1C7 /* XMPPIncomingFileTransfer.m in Sources */,
 				D9DCD5BF1E6258CF0010D1C7 /* XMPPSCRAMSHA1Authentication.m in Sources */,
 				D9DCD5C01E6258CF0010D1C7 /* XMPPIQ+XEP_0357.m in Sources */,
+				DD855F961F74F2B000E12330 /* XMPPOutOfBandResourceMessaging.m in Sources */,
 				D9DCD5C11E6258CF0010D1C7 /* XMPPvCardAvatarModule.m in Sources */,
 				D9DCD5C21E6258CF0010D1C7 /* XMPPReconnect.m in Sources */,
 				D9DCD5C31E6258CF0010D1C7 /* XMPPvCardTempAdr.m in Sources */,

--- a/Xcode/Testing-Carthage/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-Carthage/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		D9DCD70E1E625C560010D1C7 /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9DCD7191E625CAE0010D1C7 /* XMPPFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9DCD6B01E625A9B0010D1C7 /* XMPPFramework.framework */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
+		DD4003E81F75283D0078D144 /* XMPPOutOfBandResourceMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DDB40BAA1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m */; };
+		DD4003E91F75283E0078D144 /* XMPPOutOfBandResourceMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DDB40BAA1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m */; };
+		DDB40BAB1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DDB40BAA1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,6 +136,7 @@
 		D9DCD3EC1E6255E10010D1C7 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9DCD7151E625C560010D1C7 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../Testing-Shared/OMEMOElementTests.m"; sourceTree = SOURCE_ROOT; };
+		DDB40BAA1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XMPPOutOfBandResourceMessagingTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -202,6 +206,7 @@
 				D973A0791D2F18040096F3ED /* XMPPStorageHintTests.m */,
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
+				DDB40BAA1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 			);
 			name = XMPPFrameworkTests;
@@ -390,6 +395,7 @@
 				D99C5E0D1D99C48100FB068A /* OMEMOModuleTests.m in Sources */,
 				D973A0861D2F18040096F3ED /* XMPPURITests.m in Sources */,
 				D973A07F1D2F18040096F3ED /* XMPPMessageArchiveManagementTests.m in Sources */,
+				DDB40BAB1F75255100B82A93 /* XMPPOutOfBandResourceMessagingTests.m in Sources */,
 				D973A07E1D2F18040096F3ED /* XMPPHTTPFileUploadTests.m in Sources */,
 				D973A0821D2F18040096F3ED /* XMPPPushTests.swift in Sources */,
 				D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */,
@@ -414,6 +420,7 @@
 				D9DCD3DC1E6255E10010D1C7 /* OMEMOModuleTests.m in Sources */,
 				D9DCD3DD1E6255E10010D1C7 /* XMPPURITests.m in Sources */,
 				D9DCD3DE1E6255E10010D1C7 /* XMPPMessageArchiveManagementTests.m in Sources */,
+				DD4003E81F75283D0078D144 /* XMPPOutOfBandResourceMessagingTests.m in Sources */,
 				D9DCD3DF1E6255E10010D1C7 /* XMPPHTTPFileUploadTests.m in Sources */,
 				D9DCD3E01E6255E10010D1C7 /* XMPPPushTests.swift in Sources */,
 				D9DCD3E11E6255E10010D1C7 /* OMEMOElementTests.m in Sources */,
@@ -438,6 +445,7 @@
 				D9DCD7051E625C560010D1C7 /* OMEMOModuleTests.m in Sources */,
 				D9DCD7061E625C560010D1C7 /* XMPPURITests.m in Sources */,
 				D9DCD7071E625C560010D1C7 /* XMPPMessageArchiveManagementTests.m in Sources */,
+				DD4003E91F75283E0078D144 /* XMPPOutOfBandResourceMessagingTests.m in Sources */,
 				D9DCD7081E625C560010D1C7 /* XMPPHTTPFileUploadTests.m in Sources */,
 				D9DCD7091E625C560010D1C7 /* XMPPPushTests.swift in Sources */,
 				D9DCD70A1E625C560010D1C7 /* OMEMOElementTests.m in Sources */,

--- a/Xcode/Testing-Shared/XMPPOutOfBandResourceMessagingTests.m
+++ b/Xcode/Testing-Shared/XMPPOutOfBandResourceMessagingTests.m
@@ -1,0 +1,65 @@
+#import <XCTest/XCTest.h>
+#import "XMPPMockStream.h"
+
+@interface XMPPOutOfBandResourceMessagingTests : XCTestCase <XMPPOutOfBandResourceMessagingDelegate>
+
+@property (strong, nonatomic) XMPPMockStream *mockStream;
+@property (strong, nonatomic) XMPPOutOfBandResourceMessaging *outOfBandResourceMessaging;
+@property (strong, nonatomic) XCTestExpectation *delegateCallbackExpectation;
+
+@end
+
+@implementation XMPPOutOfBandResourceMessagingTests
+
+- (void)setUp
+{
+    [super setUp];
+    self.mockStream = [[XMPPMockStream alloc] init];
+    self.outOfBandResourceMessaging = [[XMPPOutOfBandResourceMessaging alloc] init];
+    [self.outOfBandResourceMessaging addDelegate:self delegateQueue:dispatch_get_main_queue()];
+    [self.outOfBandResourceMessaging activate:self.mockStream];
+}
+
+- (void)testDelegateCallback
+{
+    self.delegateCallbackExpectation = [self expectationWithDescription:@"Delegate callback received"];
+    
+    [self fakeOutOfBandResourceMessage];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testURLSchemeFiltering
+{
+    self.outOfBandResourceMessaging.relevantURLSchemes = [NSSet setWithObject:@"ftp"];
+    self.delegateCallbackExpectation = [self expectationWithDescription:@"Delegate callback not received"];
+    self.delegateCallbackExpectation.inverted = YES;
+    
+    [self fakeOutOfBandResourceMessage];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)xmppOutOfBandResourceMessaging:(XMPPOutOfBandResourceMessaging *)xmppOutOfBandResourceMessaging didReceiveOutOfBandResourceMessage:(XMPPMessage *)message
+{
+    if ([[message body] isEqualToString:@"Yeah, but do you have a license to Jabber?"]) {
+        [self.delegateCallbackExpectation fulfill];
+    }
+}
+
+- (void)fakeOutOfBandResourceMessage
+{
+    [self.mockStream fakeMessageResponse:
+     [[XMPPMessage alloc] initWithXMLString:
+      @"<message from='stpeter@jabber.org/work'"
+      @"           to='MaineBoy@jabber.org/home'>"
+      @"  <body>Yeah, but do you have a license to Jabber?</body>"
+      @"  <x xmlns='jabber:x:oob'>"
+      @"    <url>http://www.jabber.org/images/psa-license.jpg</url>"
+      @"    <desc>A license to Jabber!</desc>"
+      @"  </x>"
+      @"</message>"
+                                      error:nil]];
+}
+
+@end

--- a/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D99C5E0E1D99C48100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E701D90B894002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */; };
 		DD1E732C1ED86B7D009B529B /* XMPPPubSubTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */; };
+		DDB40BA81F750B0800B82A93 /* XMPPOutOfBandResourceMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DDB40BA71F750B0800B82A93 /* XMPPOutOfBandResourceMessagingTests.m */; };
 		FDD2AB232C05507F2045FFFC /* Pods_XMPPFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CD0B17267211A912DE2098E /* Pods_XMPPFrameworkTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +56,7 @@
 		D99C5E0C1D99C48100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6F1D90B894002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
 		DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPPubSubTests.m; path = "../../Testing-Shared/XMPPPubSubTests.m"; sourceTree = "<group>"; };
+		DDB40BA71F750B0800B82A93 /* XMPPOutOfBandResourceMessagingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = XMPPOutOfBandResourceMessagingTests.m; path = "../../Testing-Shared/XMPPOutOfBandResourceMessagingTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				D973A07A1D2F18040096F3ED /* XMPPURITests.m */,
 				D973A07B1D2F18040096F3ED /* XMPPvCardTests.m */,
 				DD1E732B1ED86B7D009B529B /* XMPPPubSubTests.m */,
+				DDB40BA71F750B0800B82A93 /* XMPPOutOfBandResourceMessagingTests.m */,
 				63F50D971C60208200CA0201 /* Info.plist */,
 				D973A06E1D2F18030096F3ED /* XMPPFrameworkTests-Bridging-Header.h */,
 			);
@@ -250,6 +253,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDB40BA81F750B0800B82A93 /* XMPPOutOfBandResourceMessagingTests.m in Sources */,
 				D973A07C1D2F18040096F3ED /* CapabilitiesHashingTest.m in Sources */,
 				D973A0811D2F18040096F3ED /* XMPPMUCLightTests.m in Sources */,
 				D973A07D1D2F18040096F3ED /* EncodeDecodeTest.m in Sources */,

--- a/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D99C5E091D95EBA100FB068A /* OMEMOTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D99C5E081D95EBA100FB068A /* OMEMOTestStorage.m */; };
 		D9E35E6E1D90B2C5002E7CF7 /* OMEMOElementTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9E35E6D1D90B2C5002E7CF7 /* OMEMOElementTests.m */; };
 		D9F20D011D836080002A8D6F /* OMEMOModuleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9F20D001D836080002A8D6F /* OMEMOModuleTests.m */; };
+		DD4003D51F7525A50078D144 /* XMPPOutOfBandResourceMessagingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4003D41F7525A50078D144 /* XMPPOutOfBandResourceMessagingTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		D99C5E081D95EBA100FB068A /* OMEMOTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOTestStorage.m; path = "../../Testing-Shared/OMEMOTestStorage.m"; sourceTree = "<group>"; };
 		D9E35E6D1D90B2C5002E7CF7 /* OMEMOElementTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOElementTests.m; path = "../../Testing-Shared/OMEMOElementTests.m"; sourceTree = "<group>"; };
 		D9F20D001D836080002A8D6F /* OMEMOModuleTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OMEMOModuleTests.m; path = "../../Testing-Shared/OMEMOModuleTests.m"; sourceTree = "<group>"; };
+		DD4003D41F7525A50078D144 /* XMPPOutOfBandResourceMessagingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPOutOfBandResourceMessagingTests.m; path = "../../Testing-Shared/XMPPOutOfBandResourceMessagingTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 				D973A0A11D2F1EF60096F3ED /* XMPPSwift.swift */,
 				D973A0A21D2F1EF60096F3ED /* XMPPURITests.m */,
 				D973A0A31D2F1EF60096F3ED /* XMPPvCardTests.m */,
+				DD4003D41F7525A50078D144 /* XMPPOutOfBandResourceMessagingTests.m */,
 				D973A0921D2F1EB10096F3ED /* Info.plist */,
 			);
 			path = XMPPFrameworkTests;
@@ -245,6 +248,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD4003D51F7525A50078D144 /* XMPPOutOfBandResourceMessagingTests.m in Sources */,
 				D973A0A41D2F1EF60096F3ED /* CapabilitiesHashingTest.m in Sources */,
 				D9F20D011D836080002A8D6F /* OMEMOModuleTests.m in Sources */,
 				D973A0A91D2F1EF60096F3ED /* XMPPMUCLightTests.m in Sources */,


### PR DESCRIPTION
This pull request implements a module managing XEP-0066 auxiliary resource URIs embedded in messages, one of the modules described in the "Currently supported XMPP extensions" section in #993.
Storage helpers implementation is not yet included here, as it depends on both #996 and #997.