### PR TITLE
Fixed persistent store directory handling when legacyPersistentStoreD…

### DIFF
--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
@@ -452,9 +452,11 @@ static NSMutableSet *databaseFileNames;
     // Previously the Peristent Story Directory was based on the Bundle Display Name but this can be Localized
     // If Peristent Story Directory already exists we will use that
     NSString *bundleDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-    NSString *legacyPersistentStoreDirectory  = [basePath stringByAppendingPathComponent:bundleDisplayName];
-    if ([fileManager fileExistsAtPath:legacyPersistentStoreDirectory]) {
-        return legacyPersistentStoreDirectory;
+    if (bundleDisplayName) {
+        NSString *legacyPersistentStoreDirectory  = [basePath stringByAppendingPathComponent:bundleDisplayName];
+        if ([fileManager fileExistsAtPath:legacyPersistentStoreDirectory]) {
+            return legacyPersistentStoreDirectory;
+        }
     }
     
     // Peristent Story Directory now uses the Bundle Identifier


### PR DESCRIPTION
This pull request fix an issue in the core data storage persistentStoreDirectory function.
When the CFBundleDisplayName is nil or empty and the legacy path (legacyPersistentStoreDirectory) is a subpath of the persistent path (persistentStoreDirectory) there is an inconsistent behaviour.
The first time the legacyPersistentStoreDirectory does not exist and the persistentStoreDirectory is returned. All the core data files are created on that directory.
The second time the legacyPersistentStoreDirectory does exist (being a subpath of persistentStoreDirectory created on the first run) and is returned. Core data files are not there so nothing is retrieved. Everything is persisted again on legacyPersistentStoreDirectory.
From the third time everything works good.