### PR TITLE
Fixes #1073. Correct nullability for lastDisconnect

### DIFF
--- a/Extensions/XEP-0198/XMPPStreamManagement.h
+++ b/Extensions/XEP-0198/XMPPStreamManagement.h
@@ -467,7 +467,7 @@ NS_ASSUME_NONNULL_BEGIN
 **/
 - (void)setResumptionId:(nullable NSString *)resumptionId
                 timeout:(uint32_t)timeout
-         lastDisconnect:(NSDate *)date
+         lastDisconnect:(nullable NSDate *)date
               forStream:(XMPPStream *)stream;
 
 /**
@@ -485,7 +485,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param stream
  *   The associated xmppStream (standard parameter for storage classes)
 **/
-- (void)setLastDisconnect:(NSDate *)date
+- (void)setLastDisconnect:(nullable NSDate *)date
       lastHandledByClient:(uint32_t)lastHandledByClient
                 forStream:(XMPPStream *)stream;
 
@@ -510,7 +510,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param stream
  *   The associated xmppStream (standard parameter for storage classes)
 **/
-- (void)setLastDisconnect:(NSDate *)date
+- (void)setLastDisconnect:(nullable NSDate *)date
       lastHandledByServer:(uint32_t)lastHandledByServer
    pendingOutgoingStanzas:(nullable NSArray<XMPPStreamManagementOutgoingStanza*> *)pendingOutgoingStanzas
                 forStream:(XMPPStream *)stream;
@@ -573,7 +573,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param stream
  *   The associated xmppStream (standard parameter for storage classes)
 **/
-- (void)setLastDisconnect:(NSDate *)date
+- (void)setLastDisconnect:(nullable NSDate *)date
       lastHandledByClient:(uint32_t)lastHandledByClient
       lastHandledByServer:(uint32_t)lastHandledByServer
    pendingOutgoingStanzas:(nullable NSArray<XMPPStreamManagementOutgoingStanza*> *)pendingOutgoingStanzas


### PR DESCRIPTION
The makes all uses of `lastDisconnect` within `XMPPStreamManagementStorage ` nullable. This is how `lastDisconnect` is treated by `XMPPStreamManagementMemoryStorage`, and there are cases where `lastDisconnect` is nil when passed to the delegate (if a disconnect has never occurred). This causes a crash in Swift when the nil is unwrapped.