### PR TITLE
Update XMPPIncomingFileTransfer.m

### DIFF
--- a/Extensions/FileTransfer/XMPPIncomingFileTransfer.m
+++ b/Extensions/FileTransfer/XMPPIncomingFileTransfer.m
@@ -571,9 +571,12 @@ NSString *const XMPPIncomingFileTransferErrorDomain = @"XMPPIncomingFileTransfer
 - (BOOL)xmppStream:(XMPPStream *)sender didReceiveIQ:(XMPPIQ *)iq
 {
   if (_transferState == XMPPIFTStateNone && [self isDiscoInfoIQ:iq]) {
-    [self sendIdentity:iq];
-    _transferState = XMPPIFTStateWaitingForSIOffer;
-    return YES;
+    if ([[iq elementForName:@"query"] elementForName:@"identity"] == nil) {
+      [self sendIdentity:iq];
+      _transferState = XMPPIFTStateWaitingForSIOffer;
+      
+      return YES;
+    }
   }
 
   if ((_transferState == XMPPIFTStateNone || _transferState == XMPPIFTStateWaitingForSIOffer)


### PR DESCRIPTION
fixed `XMPPIncomingFileTransfer` is stuck on state "XMPPIFTStateWaitingForSIOffer" when receiving disco#info while sending a file.

if `XMPPOutgoingFileTransfer` and `XMPPIncomingFileTransfer` are both activated, `XMPPOutgoingFileTransfer` sends disco#info request to recipient client, and when recipient returns disco#info request, client's `XMPPIncomingFileTransfer` sends identity and makes its state to `XMPPIFTStateWaitingForSIOffer`.

So unless XMPPStream receives disco#info request, `XMPPIncomingfileTransfer`'s state is not a `XMPPIFTStateNone`, so disco#info result will never be sended.