### PR TITLE
Add _Nullable to XMPPRoster

### DIFF
--- a/Extensions/Roster/CoreDataStorage/XMPPRosterCoreDataStorage.m
+++ b/Extensions/Roster/CoreDataStorage/XMPPRosterCoreDataStorage.m
@@ -487,7 +487,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 	}];
 }
 
-- (NSArray *)jidsForXMPPStream:(XMPPStream *)stream{
+- (NSArray *)jidsForXMPPStream:(XMPPStream * _Nullable)stream {
     
     XMPPLogTrace();
     

--- a/Extensions/Roster/MemoryStorage/XMPPRosterMemoryStorage.m
+++ b/Extensions/Roster/MemoryStorage/XMPPRosterMemoryStorage.m
@@ -804,7 +804,7 @@
 	[[self multicastDelegate] xmppRosterDidChange:self];
 }
 
-- (NSArray *)jidsForXMPPStream:(XMPPStream *)stream
+- (NSArray *)jidsForXMPPStream:(XMPPStream * _Nullable)stream
 {
     XMPPLogTrace();
 	AssertParentQueue();

--- a/Extensions/Roster/XMPPRoster.h
+++ b/Extensions/Roster/XMPPRoster.h
@@ -337,7 +337,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)clearAllResourcesForXMPPStream:(XMPPStream *)stream;
 - (void)clearAllUsersAndResourcesForXMPPStream:(XMPPStream *)stream;
 
-- (NSArray<XMPPJID*> *)jidsForXMPPStream:(XMPPStream *)stream;
+- (NSArray<XMPPJID*> *)jidsForXMPPStream:(XMPPStream * _Nullable)stream;
 
 - (void)getSubscription:(NSString * _Nullable * _Nullable)subscription
                     ask:(NSString * _Nullable * _Nullable)ask


### PR DESCRIPTION
Add _Nullable to method of XMPPRoster:

`(NSArray *)jidsForXMPPStream:(XMPPStream * _Nullable)stream`

to be able to call this from swift with a nil stream reference.

This is especially useful when user wants to retrieve roster from swift code and stream is not yet connected.