### PR TITLE
Fix crashes in XMPPvCardTempEmail and XMPPvCardTempTel initialize

### DIFF
--- a/Extensions/XEP-0054/XMPPvCardTemp.h
+++ b/Extensions/XEP-0054/XMPPvCardTemp.h
@@ -55,7 +55,7 @@ extern NSString *const kXMPPvCardTempElement;
 
 @property (nonatomic, strong, nullable) NSArray<XMPPvCardTempAdr*> *addresses;
 @property (nonatomic, strong, nullable) NSArray<XMPPvCardTempLabel*> *labels;
-@property (nonatomic, strong, nullable) NSArray<XMPPvCardTempTel*> *telecomsAddresses;
+@property (nonatomic, strong) NSArray<XMPPvCardTempTel*> *telecomsAddresses;
 @property (nonatomic, strong) NSArray<XMPPvCardTempEmail*> *emailAddresses;
 
 @property (nonatomic, strong, nullable) XMPPJID *jid;

--- a/Extensions/XEP-0054/XMPPvCardTemp.m
+++ b/Extensions/XEP-0054/XMPPvCardTemp.m
@@ -315,11 +315,45 @@ NSString *const kXMPPvCardTempElement = @"vCard";
 - (void)clearLabels { }
 
 
-- (NSArray *)telecomsAddresses { return nil; }
-- (void)addTelecomsAddress:(XMPPvCardTempTel *)tel { }
-- (void)removeTelecomsAddress:(XMPPvCardTempTel *)tel { }
-- (void)setTelecomsAddresses:(NSArray *)tels { }
-- (void)clearTelecomsAddresses { }
+- (NSArray *)telecomsAddresses {
+    NSMutableArray *result = [NSMutableArray new];
+    NSArray *tels = [self elementsForName:@"TEL"];
+    for (NSXMLElement *tel in tels) {
+        XMPPvCardTempTel *vCardTempTel = [XMPPvCardTempTel vCardTelFromElement:tel];
+        [result addObject:vCardTempTel];
+    }
+        
+    return result;
+}
+
+
+- (void)addTelecomsAddress:(XMPPvCardTempTel *)tel {
+    [self addChild:tel];
+}
+
+
+- (void)removeTelecomsAddress:(XMPPvCardTempTel *)tel {
+    NSArray *telElements = [self elementsForName:@"TEL"];
+    for (NSXMLElement *element in telElements) {
+        XMPPvCardTempTel *vCardTempTel = [XMPPvCardTempTel vCardTelFromElement:[element copy]];
+        if ([vCardTempTel.number isEqualToString:tel.number]) {
+            NSUInteger index = [[self children] indexOfObject:element];
+            [self removeChildAtIndex:index];
+        }
+    }
+}
+
+- (void)setTelecomsAddresses:(NSArray<XMPPvCardTempTel *> *)tels {
+    [self clearTelecomsAddresses];
+    for (XMPPvCardTempTel *tel in tels) {
+        [self addTelecomsAddress:tel];
+    }
+}
+
+
+- (void)clearTelecomsAddresses {
+    [self removeElementsForName:@"TEL"];
+}
 
 
 - (NSArray *)emailAddresses {

--- a/Extensions/XEP-0054/XMPPvCardTempEmail.m
+++ b/Extensions/XEP-0054/XMPPvCardTempEmail.m
@@ -117,7 +117,7 @@
 }
 
 
-- (void)setIsUserid:(NSString *)userid {
+- (void)setUserid:(NSString *)userid {
 	XMPP_VCARD_SET_STRING_CHILD(userid, @"USERID");
 }
 

--- a/Extensions/XEP-0054/XMPPvCardTempTel.m
+++ b/Extensions/XEP-0054/XMPPvCardTempTel.m
@@ -116,8 +116,8 @@
 }
 
 
-- (void)setIsMessaging:(BOOL)msg {
-	XMPP_VCARD_SET_EMPTY_CHILD(msg && ![self hasMessaging], @"MSG");
+- (void)setHasMessaging:(BOOL)hasMessaging {
+	XMPP_VCARD_SET_EMPTY_CHILD(hasMessaging && ![self hasMessaging], @"MSG");
 }
 
 

--- a/Xcode/Testing-Swift/XMPPvCardTempTests.swift
+++ b/Xcode/Testing-Swift/XMPPvCardTempTests.swift
@@ -1,0 +1,92 @@
+//
+//  XMPPvCardTempTests.swift
+//  XMPPFrameworkSwiftTests
+//
+//  Created by Oleg Langer on 07.04.20.
+//
+
+import XCTest
+import XMPPFramework
+
+class XMPPvCardTempTests: XCTestCase {
+    var xmlString: String!
+    var sut: XMPPvCardTemp!
+    
+    override func setUp() {
+        xmlString = """
+        <vCard xmlns="vcard-temp">
+            <NICKNAME>DESKTOP</NICKNAME>
+            <EMAIL>
+                <INTERNET/>
+                <USERID>q_dekstop@example.com</USERID>
+            </EMAIL>
+            <TEL>
+                <WORK/>
+                <VOICE/>
+                <NUMBER>303-308-3282</NUMBER>
+            </TEL>
+        </vCard>
+        """
+        let element = try! DDXMLElement(xmlString: xmlString)
+        sut = XMPPvCardTemp.vCardTemp(from: element)
+    }
+
+    func testCreateFromXMLString() {
+        XCTAssertNotNil(sut)
+    }
+    
+    func testGetEmailAddress() {
+        XCTAssertEqual(sut.emailAddresses.count, 1)
+        let email = sut.emailAddresses.first
+        XCTAssertNotNil(email)
+        XCTAssertEqual(email?.userid, "q_dekstop@example.com")
+        XCTAssertEqual(email?.isInternet, true)
+    }
+    
+    func testRemoveEmailAddress() {
+        let email = sut.emailAddresses.first!
+        sut.removeEmailAddress(email)
+        
+        XCTAssertEqual(sut.emailAddresses.count, 0)
+    }
+    
+    func testAddEmailAddress() {
+        // Remove all first
+        sut.clearEmailAddresses()
+        
+        let element = DDXMLElement(name: "EMAIL")
+        let newMail = XMPPvCardTempEmail.vCardEmail(from: element)
+        newMail.isWork = true
+        newMail.userid = "new_mail@example.com"
+        sut.addEmailAddress(newMail)
+        
+        XCTAssertEqual(sut.emailAddresses.first, newMail)
+    }
+    
+    func testGetTelecomAddress() {
+        XCTAssertEqual(sut.telecomsAddresses.count, 1)
+        let tel = sut.telecomsAddresses.first!
+        XCTAssertTrue(tel.isWork)
+        XCTAssertTrue(tel.isVoice)
+        XCTAssertEqual(tel.number, "303-308-3282")
+    }
+    
+    func testRemoveTelecomAddresses() {
+        let tel = sut.telecomsAddresses.first!
+        sut.removeTelecomsAddress(tel)
+        XCTAssertEqual(sut.telecomsAddresses.count, 0)
+    }
+    
+    func testAddTelecomAddress() {
+        sut.clearTelecomsAddresses()
+        
+        let element = DDXMLElement(name: "TEL")
+        let newTel = XMPPvCardTempTel.vCardTel(from: element)
+        newTel.isCell = true
+        newTel.number = "101"
+        sut.addTelecomsAddress(newTel)
+        
+        XCTAssertEqual(sut.telecomsAddresses.count, 1)
+        XCTAssertEqual(sut.telecomsAddresses.first!, newTel)
+    }
+}

--- a/Xcode/Testing-Swift/XMPPvCardTempTests.swift
+++ b/Xcode/Testing-Swift/XMPPvCardTempTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import XMPPFramework
 
 class XMPPvCardTempTests: XCTestCase {
     var xmlString: String!
@@ -27,7 +26,7 @@ class XMPPvCardTempTests: XCTestCase {
             </TEL>
         </vCard>
         """
-        let element = try! DDXMLElement(xmlString: xmlString)
+        let element = try! XMLElement(xmlString: xmlString)
         sut = XMPPvCardTemp.vCardTemp(from: element)
     }
 
@@ -54,7 +53,7 @@ class XMPPvCardTempTests: XCTestCase {
         // Remove all first
         sut.clearEmailAddresses()
         
-        let element = DDXMLElement(name: "EMAIL")
+        let element = XMLElement(name: "EMAIL")
         let newMail = XMPPvCardTempEmail.vCardEmail(from: element)
         newMail.isWork = true
         newMail.userid = "new_mail@example.com"
@@ -80,7 +79,7 @@ class XMPPvCardTempTests: XCTestCase {
     func testAddTelecomAddress() {
         sut.clearTelecomsAddresses()
         
-        let element = DDXMLElement(name: "TEL")
+        let element = XMLElement(name: "TEL")
         let newTel = XMPPvCardTempTel.vCardTel(from: element)
         newTel.isCell = true
         newTel.number = "101"

--- a/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-iOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1A5DC58D2566E3FC0AAB5BA7 /* Pods_XMPPFrameworkSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6923171573DDCA8E2DEC3A22 /* Pods_XMPPFrameworkSwiftTests.framework */; };
+		9943D285243CA2EB000A9DFC /* XMPPvCardTempTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9943D284243CA2EB000A9DFC /* XMPPvCardTempTests.swift */; };
 		D945D6F71FD9EA2100C7502C /* XMPPPresenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D945D6F61FD9EA2100C7502C /* XMPPPresenceTests.swift */; };
 		D973A07C1D2F18040096F3ED /* CapabilitiesHashingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D973A06F1D2F18040096F3ED /* CapabilitiesHashingTest.m */; };
 		D973A07D1D2F18040096F3ED /* EncodeDecodeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D973A0701D2F18040096F3ED /* EncodeDecodeTest.m */; };
@@ -45,6 +46,7 @@
 		63F50D921C60208200CA0201 /* XMPPFrameworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XMPPFrameworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		63F50D971C60208200CA0201 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6923171573DDCA8E2DEC3A22 /* Pods_XMPPFrameworkSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_XMPPFrameworkSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9943D284243CA2EB000A9DFC /* XMPPvCardTempTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = XMPPvCardTempTests.swift; path = "../../Testing-Swift/XMPPvCardTempTests.swift"; sourceTree = "<group>"; };
 		AE993B61B8D33F0468A9B133 /* Pods-XMPPFrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-XMPPFrameworkTests/Pods-XMPPFrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
 		D945D6F61FD9EA2100C7502C /* XMPPPresenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XMPPPresenceTests.swift; path = "../../Testing-Swift/XMPPPresenceTests.swift"; sourceTree = "<group>"; };
 		D973A06E1D2F18030096F3ED /* XMPPFrameworkTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XMPPFrameworkTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 				D9B81AC61FBCD39E00455683 /* XMPPMockStream.h */,
 				D9B81AC51FBCD39E00455683 /* XMPPMockStream.m */,
 				D9A7B03F1FB988EC005183CD /* Info.plist */,
+				9943D284243CA2EB000A9DFC /* XMPPvCardTempTests.swift */,
 			);
 			path = XMPPFrameworkSwiftTests;
 			sourceTree = "<group>";
@@ -411,6 +414,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D9B81AC91FBCD3B400455683 /* XMPPBookmarksModuleTests.swift in Sources */,
+				9943D285243CA2EB000A9DFC /* XMPPvCardTempTests.swift in Sources */,
 				D9B81AC71FBCD39E00455683 /* XMPPMockStream.m in Sources */,
 				D945D6F71FD9EA2100C7502C /* XMPPPresenceTests.swift in Sources */,
 			);

--- a/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
+++ b/Xcode/Testing-macOS/XMPPFrameworkTests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4A6D92D0C7C1950CBA77BE55 /* Pods_XMPPFrameworkTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23C81F1C22F160BD2130E79A /* Pods_XMPPFrameworkTests.framework */; };
+		9943D287243D0E17000A9DFC /* XMPPvCardTempTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9943D286243D0E17000A9DFC /* XMPPvCardTempTests.swift */; };
 		B407FF87953F6A78BCCE2871 /* Pods_XMPPFrameworkSwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 777EEF98731B0EC5DBD49953 /* Pods_XMPPFrameworkSwiftTests.framework */; };
 		D93B87901FBCE8D6002B6CB7 /* XMPPBookmarksModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D93B878F1FBCE8D6002B6CB7 /* XMPPBookmarksModuleTests.swift */; };
 		D93B87931FBCE90D002B6CB7 /* XMPPMockStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D93B87911FBCE90C002B6CB7 /* XMPPMockStream.m */; };
@@ -43,6 +44,7 @@
 		5AA422BDF36502C8A148D622 /* Pods-XMPPFrameworkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-XMPPFrameworkTests/Pods-XMPPFrameworkTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5CE125FD447C51125BCAAAFF /* Pods-XMPPFrameworkSwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-XMPPFrameworkSwiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-XMPPFrameworkSwiftTests/Pods-XMPPFrameworkSwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 		777EEF98731B0EC5DBD49953 /* Pods_XMPPFrameworkSwiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_XMPPFrameworkSwiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9943D286243D0E17000A9DFC /* XMPPvCardTempTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XMPPvCardTempTests.swift; path = "../../Testing-Swift/XMPPvCardTempTests.swift"; sourceTree = "<group>"; };
 		D93B878E1FBCE8D6002B6CB7 /* XMPPFrameworkTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XMPPFrameworkTests-Bridging-Header.h"; path = "../../Testing-Swift/XMPPFrameworkTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		D93B878F1FBCE8D6002B6CB7 /* XMPPBookmarksModuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XMPPBookmarksModuleTests.swift; path = "../../Testing-Swift/XMPPBookmarksModuleTests.swift"; sourceTree = "<group>"; };
 		D93B87911FBCE90C002B6CB7 /* XMPPMockStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XMPPMockStream.m; path = "../../Testing-Shared/XMPPMockStream.m"; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 		D9A7B02E1FB985BE005183CD /* XMPPFrameworkSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
+				9943D286243D0E17000A9DFC /* XMPPvCardTempTests.swift */,
 				D945D6F81FD9EA3B00C7502C /* XMPPPresenceTests.swift */,
 				D93B87921FBCE90D002B6CB7 /* XMPPMockStream.h */,
 				D93B87911FBCE90C002B6CB7 /* XMPPMockStream.m */,
@@ -405,6 +408,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D93B87931FBCE90D002B6CB7 /* XMPPMockStream.m in Sources */,
+				9943D287243D0E17000A9DFC /* XMPPvCardTempTests.swift in Sources */,
 				D93B87901FBCE8D6002B6CB7 /* XMPPBookmarksModuleTests.swift in Sources */,
 				D945D6F91FD9EA3C00C7502C /* XMPPPresenceTests.swift in Sources */,
 			);


### PR DESCRIPTION
Fixes #1050 and #1118.

Setter methods in `XMPPcVardTempEmail` and `XMPPcVardTempTel` had typing mistakes. Must have been happened sometime during 3.7 to 4.0 transition. 
These types do not allow adding properties, that's why the allocated size is compared to the size of `NSXMLElement` in `initialize`. 

```
+ (void)initialize {
        // .....
	size_t superSize = class_getInstanceSize([NSXMLElement class]);
	size_t ourSize   = class_getInstanceSize([XMPPvCardTempEmail class]);
	
	if (superSize != ourSize)
	{
		XMPPLogError(@"Adding instance variables to XMPPvCardTempEmail is not currently supported!");
		
		[DDLog flushLog];
		exit(15);
	}
}
```

Every added property has to have matching get and set overwrites, otherwise ObjC will allocate memory for the property and the size check will fail.
The linked issue describe that behavior.

I also added missing implementation for `TEL` and few tests for `XMPPvCardTemp`.