### PR TITLE
presence date set in XMPPResourceCoreDataStorageObject

### DIFF
--- a/Extensions/Roster/CoreDataStorage/XMPPResourceCoreDataStorageObject.m
+++ b/Extensions/Roster/CoreDataStorage/XMPPResourceCoreDataStorageObject.m
@@ -168,6 +168,12 @@
 		return;
 	}
 	
+	self.presenceDate = [presence delayedDeliveryDate];
+	    if (self.presenceDate == nil)
+	    {
+		self.presenceDate = [[NSDate alloc] init];
+	    }
+	
 	self.jid = jid;
 	self.presence = presence;
 	


### PR DESCRIPTION
Refactored with a tip from robbiehanson#629. Without the the added code, presenceDate is always nil for any XMPPResourceCoreDataStorageObject