### PR TITLE
Message Archive Management handling remote messages by inferring direction instead. Adds MAM 2 support.

### DIFF
--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving.xcdatamodeld/.xccurrentversion
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>XMPPMessageArchiving.xcdatamodel</string>
+	<string>XMPPMessageArchiving 2.xcdatamodel</string>
 </dict>
 </plist>

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving.xcdatamodeld/XMPPMessageArchiving 2.xcdatamodel/contents
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving.xcdatamodeld/XMPPMessageArchiving 2.xcdatamodel/contents
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="23A344" minimumToolsVersion="Xcode 7.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="XMPPMessageArchiving_Contact_CoreDataObject" representedClassName="XMPPMessageArchiving_Contact_CoreDataObject" syncable="YES">
+        <attribute name="bareJid" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="bareJidStr" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="mostRecentMessageBody" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="mostRecentMessageOutgoing" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="mostRecentMessageTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="streamBareJidStr" attributeType="String" indexed="YES" syncable="YES"/>
+    </entity>
+    <entity name="XMPPMessageArchiving_Message_CoreDataObject" representedClassName="XMPPMessageArchiving_Message_CoreDataObject" syncable="YES">
+        <attribute name="bareJid" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="bareJidStr" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="body" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="composing" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="message" optional="YES" transient="YES" syncable="YES"/>
+        <attribute name="messageId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="messageStr" attributeType="String" syncable="YES"/>
+        <attribute name="outgoing" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="streamBareJidStr" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="thread" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+    </entity>
+</model>

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -384,7 +384,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 	return [super configureWithParent:aParent queue:queue];
 }
 
-- (void)archiveMessage:(XMPPMessage *)message outgoing:(BOOL)isOutgoing xmppStream:(XMPPStream *)xmppStream
+- (void)archiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)xmppStream
 {
 	// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
 	// Obtain the full JID of the current user.
@@ -400,7 +400,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 	// - It's not incoming (determined by the 'to' JID not matching the current user's JID).
 	// AND
 	// - Either there's no 'from' JID (it's empty), OR the 'from' JID matches the current user's JID.
-	isOutgoing = !isIncoming && (!isFromFieldPresent || [[message from].full isEqualToString:ownJid]);
+	BOOL isOutgoing = !isIncoming && (!isFromFieldPresent || [[message from].full isEqualToString:ownJid]);
 
 	// Message should either have a body, or be a composing notification
 	

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -3,6 +3,8 @@
 #import "XMPPLogging.h"
 #import "NSXMLElement+XEP_0203.h"
 #import "XMPPMessage+XEP_0085.h"
+@import FirebaseCrashlytics;
+
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
@@ -386,6 +388,9 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 
 - (void)archiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)xmppStream
 {
+	
+	NSString *xmlString = [message XMLString];
+	[[FIRCrashlytics crashlytics] log:[NSString stringWithFormat:@"XML content: %@", xmlString]];
 	// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
     // Obtain the full JID of the current user.
     NSString *ownJid = [xmppStream.myJID bare];

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -3,8 +3,6 @@
 #import "XMPPLogging.h"
 #import "NSXMLElement+XEP_0203.h"
 #import "XMPPMessage+XEP_0085.h"
-@import FirebaseCrashlytics;
-
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
@@ -388,9 +386,6 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 
 - (void)archiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)xmppStream
 {
-	
-	NSString *xmlString = [message XMLString];
-	[[FIRCrashlytics crashlytics] log:[NSString stringWithFormat:@"XML content: %@", xmlString]];
 	// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
     // Obtain the full JID of the current user.
     NSString *ownJid = [xmppStream.myJID bare];

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -386,10 +386,21 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 
 - (void)archiveMessage:(XMPPMessage *)message outgoing:(BOOL)isOutgoing xmppStream:(XMPPStream *)xmppStream
 {
-	// Infer if message is incoming or outgoing
+	// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
+	// Obtain the full JID of the current user.
 	NSString *ownJid = [xmppStream.myJID full];
+
+	// Check if the 'to' JID of the message matches the current user's JID, indicating it's an incoming message.
 	BOOL isIncoming = [[message to].full isEqualToString:ownJid];
-	isOutgoing = !isIncoming && [[message from].full isEqualToString:ownJid];
+
+	// Determine if the 'from' JID field in the message is present and not empty.
+	BOOL isFromFieldPresent = ([message from] != nil && [[message from].full length] > 0);
+
+	// The message is outgoing if:
+	// - It's not incoming (determined by the 'to' JID not matching the current user's JID).
+	// AND
+	// - Either there's no 'from' JID (it's empty), OR the 'from' JID matches the current user's JID.
+	isOutgoing = !isIncoming && (!isFromFieldPresent || [[message from].full isEqualToString:ownJid]);
 
 	// Message should either have a body, or be a composing notification
 	

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -466,18 +466,6 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
         XMPPJID *myJid = [self myJIDForXMPPStream:xmppStream];
         XMPPJID *messageJid = isOutgoing ? [message to] : [message from];
 
-        NSString *messageId = [[message attributeForName:@"id"] stringValue];
-
-        XMPPMessageArchiving_Message_CoreDataObject *existingMessageWithSameId = [self messageWithId:messageId managedObjectContext:moc];
-
-        
-        if (existingMessageWithSameId) {
-            // A message with this ID already exists in the database and it's not a composing message.
-            // No need to proceed.
-            XMPPLogVerbose(@"Message with ID %@ already exists. Skipping.", messageId);
-            return; // Skip processing this message further.
-        }
-		
 		// Fetch-n-Update OR Insert new message
 		
 		XMPPMessageArchiving_Message_CoreDataObject *archivedMessage =

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -387,20 +387,11 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 - (void)archiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)xmppStream
 {
 	// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
-	// Obtain the full JID of the current user.
-	NSString *ownJid = [xmppStream.myJID full];
+    // Obtain the full JID of the current user.
+    NSString *ownJid = [xmppStream.myJID bare];
 
-	// Check if the 'to' JID of the message matches the current user's JID, indicating it's an incoming message.
-	BOOL isIncoming = [[message to].full isEqualToString:ownJid];
-
-	// Determine if the 'from' JID field in the message is present and not empty.
-	BOOL isFromFieldPresent = ([message from] != nil && [[message from].full length] > 0);
-
-	// The message is outgoing if:
-	// - It's not incoming (determined by the 'to' JID not matching the current user's JID).
-	// AND
-	// - Either there's no 'from' JID (it's empty), OR the 'from' JID matches the current user's JID.
-	BOOL isOutgoing = !isIncoming && (!isFromFieldPresent || [[message from].full isEqualToString:ownJid]);
+    // Check if the 'from' JID of the message matches the current user's JID, indicating it's an outgoing message.
+    BOOL isOutgoing = [[message from].full isEqualToString:ownJid];
 
 	// Message should either have a body, or be a composing notification
 	

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -391,7 +391,7 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
     NSString *ownJid = [xmppStream.myJID bare];
 
     // Check if the 'from' JID of the message matches the current user's JID, indicating it's an outgoing message.
-    BOOL isOutgoing = [[message from].full isEqualToString:ownJid];
+    BOOL isOutgoing = [[message from].bare isEqualToString:ownJid];
 
 	// Message should either have a body, or be a composing notification
 	

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -197,41 +197,6 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 	return result;
 }
 
-- (XMPPMessageArchiving_Message_CoreDataObject *)messageWithId:(NSString *)messageId
-                                           managedObjectContext:(NSManagedObjectContext *)moc
-{
-    if (!messageId) {
-        XMPPLogError(@"%@: %@ - messageId is nil", THIS_FILE, THIS_METHOD);
-        return nil;
-    }
-    
-    XMPPMessageArchiving_Message_CoreDataObject *result = nil;
-    
-    NSEntityDescription *messageEntity = [self messageEntity:moc];
-    
-    NSString *predicateFrmt = @"messageId == %@";
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:predicateFrmt, messageId];
-    
-    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"timestamp" ascending:NO];
-    
-    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
-    fetchRequest.entity = messageEntity;
-    fetchRequest.predicate = predicate;
-    fetchRequest.sortDescriptors = @[sortDescriptor];
-    fetchRequest.fetchLimit = 1;
-    
-    NSError *error = nil;
-    NSArray *results = [moc executeFetchRequest:fetchRequest error:&error];
-    
-    if (results == nil || error) {
-        XMPPLogError(@"%@: %@ - Error executing fetchRequest: %@, Error: %@", THIS_FILE, THIS_METHOD, fetchRequest, error.localizedDescription);
-    } else {
-        result = (XMPPMessageArchiving_Message_CoreDataObject *)[results lastObject];
-    }
-    
-    return result;
-}
-
 - (BOOL)messageContainsRelevantContent:(XMPPMessage *)message
 {
     for (NSString *XPath in self.relevantContentXPaths) {

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -423,9 +423,6 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 
 - (void)archiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)xmppStream
 {
-    NSString *xmlString = [message XMLString];
-    [[FIRCrashlytics crashlytics] log:[NSString stringWithFormat:@"XML content: %@", xmlString]];
-    
 	// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
     // Obtain the full JID of the current user.
     NSString *ownJid = [xmppStream.myJID bare];

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -386,6 +386,11 @@ static XMPPMessageArchivingCoreDataStorage *sharedInstance;
 
 - (void)archiveMessage:(XMPPMessage *)message outgoing:(BOOL)isOutgoing xmppStream:(XMPPStream *)xmppStream
 {
+	// Infer if message is incoming or outgoing
+	NSString *ownJid = [xmppStream.myJID full];
+	BOOL isIncoming = [[message to].full isEqualToString:ownJid];
+	isOutgoing = !isIncoming && [[message from].full isEqualToString:ownJid];
+
 	// Message should either have a body, or be a composing notification
 	
 	NSString *messageBody = [[message elementForName:@"body"] stringValue];

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.m
@@ -4,7 +4,6 @@
 #import "NSXMLElement+XEP_0203.h"
 #import "XMPPMessage+XEP_0085.h"
 #import "XMPPMessage.h"
-@import FirebaseCrashlytics;
 
 
 #if ! __has_feature(objc_arc)

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.h
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.h
@@ -31,6 +31,8 @@
 
 @property (nonatomic, strong) NSString * streamBareJidStr;
 
+@property (nonatomic, strong) NSString * messageId;
+
 /**
  * This method is called immediately before the object is inserted into the managedObjectContext.
  * At this point, all normal properties have been set.

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.m
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchiving_Message_CoreDataObject.m
@@ -23,6 +23,7 @@
 @dynamic composing;
 @dynamic timestamp;
 @dynamic streamBareJidStr;
+@dynamic messageId;
 
 #pragma mark Transient message
 
@@ -71,6 +72,21 @@
 	
 	[self didChangeValueForKey:@"message"];
 	[self didChangeValueForKey:@"messageStr"];
+}
+
+#pragma mark - MessageId
+
+- (NSString *)messageId {
+    [self willAccessValueForKey:@"messageId"];
+    NSString *tmp = [self primitiveValueForKey:@"messageId"];
+    [self didAccessValueForKey:@"messageId"];
+    return tmp;
+}
+
+- (void)setMessageId:(NSString *)newMessageId {
+    [self willChangeValueForKey:@"messageId"];
+    [self setPrimitiveValue:newMessageId forKey:@"messageId"];
+    [self didChangeValueForKey:@"messageId"];
 }
 
 #pragma mark Transient bareJid

--- a/Extensions/XEP-0136/XMPPMessageArchiving.h
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.h
@@ -99,7 +99,7 @@
 /**
  * 
 **/
-- (void)archiveMessage:(XMPPMessage *)message outgoing:(BOOL)isOutgoing xmppStream:(XMPPStream *)stream;
+- (void)archiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)stream;
 
 @optional
 

--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -234,19 +234,10 @@
 		
 		// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
 		// Obtain the full JID of the current user.
-		NSString *ownJid = [xmppStream.myJID full];
+		NSString *ownJid = [xmppStream.myJID bare];
 
-		// Check if the 'to' JID of the message matches the current user's JID, indicating it's an incoming message.
-		BOOL isIncoming = [[message to].full isEqualToString:ownJid];
-
-		// Determine if the 'from' JID field in the message is present and not empty.
-		BOOL isFromFieldPresent = ([message from] != nil && [[message from].full length] > 0);
-
-		// The message is outgoing if:
-		// - It's not incoming (determined by the 'to' JID not matching the current user's JID).
-		// AND
-		// - Either there's no 'from' JID (it's empty), OR the 'from' JID matches the current user's JID.
-		BOOL isOutgoing = !isIncoming && (!isFromFieldPresent || [[message from].full isEqualToString:ownJid]);
+		// Check if the 'from' JID of the message matches the current user's JID, indicating it's an outgoing message.
+		isOutgoing = [[message from].full isEqualToString:ownJid];
 		
 		XMPPJID *messageJid;
 		if (isOutgoing)

--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -181,7 +181,7 @@
 #pragma mark Utilities
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)shouldArchiveMessage:(XMPPMessage *)message outgoing:(BOOL)isOutgoing xmppStream:(XMPPStream *)xmppStream
+- (BOOL)shouldArchiveMessage:(XMPPMessage *)message xmppStream:(XMPPStream *)xmppStream
 {
 	// XEP-0136 Section 2.9: Preferences precedence rules:
 	// 
@@ -231,6 +231,22 @@
 		// that exact JID only rather than <*@example.com>, <*@example.com/*>, or <example.com/*>, and
 		// a JID value such as "localpart@example.com" matches that exact JID only rather than
 		// <localpart@example.com/*>.
+		
+		// Infer if message is incoming or outgoing (Fixes a bug when Message Archive Managment is used.)
+		// Obtain the full JID of the current user.
+		NSString *ownJid = [xmppStream.myJID full];
+
+		// Check if the 'to' JID of the message matches the current user's JID, indicating it's an incoming message.
+		BOOL isIncoming = [[message to].full isEqualToString:ownJid];
+
+		// Determine if the 'from' JID field in the message is present and not empty.
+		BOOL isFromFieldPresent = ([message from] != nil && [[message from].full length] > 0);
+
+		// The message is outgoing if:
+		// - It's not incoming (determined by the 'to' JID not matching the current user's JID).
+		// AND
+		// - Either there's no 'from' JID (it's empty), OR the 'from' JID matches the current user's JID.
+		BOOL isOutgoing = !isIncoming && (!isFromFieldPresent || [[message from].full isEqualToString:ownJid]);
 		
 		XMPPJID *messageJid;
 		if (isOutgoing)
@@ -394,9 +410,9 @@
 					XMPPMessage *message = [XMPPMessage messageWithType:@"chat" to:to];
 					[message addChild:body];
 					
-					if ([self shouldArchiveMessage:message outgoing:YES xmppStream:sender])
+					if ([self shouldArchiveMessage:message xmppStream:sender])
 					{
-						[xmppMessageArchivingStorage archiveMessage:message outgoing:YES xmppStream:sender];
+						[xmppMessageArchivingStorage archiveMessage:message xmppStream:sender];
 					}
 				}
 			}
@@ -412,9 +428,9 @@
 {
 	XMPPLogTrace();
 	
-	if ([self shouldArchiveMessage:message outgoing:YES xmppStream:sender])
+	if ([self shouldArchiveMessage:message xmppStream:sender])
 	{
-		[xmppMessageArchivingStorage archiveMessage:message outgoing:YES xmppStream:sender];
+		[xmppMessageArchivingStorage archiveMessage:message xmppStream:sender];
 	}
 }
 
@@ -422,9 +438,9 @@
 {
 	XMPPLogTrace();
 	
-	if ([self shouldArchiveMessage:message outgoing:NO xmppStream:sender])
+	if ([self shouldArchiveMessage:message xmppStream:sender])
 	{
-		[xmppMessageArchivingStorage archiveMessage:message outgoing:NO xmppStream:sender];
+		[xmppMessageArchivingStorage archiveMessage:message xmppStream:sender];
 	}
 }
 

--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -237,7 +237,7 @@
 		NSString *ownJid = [xmppStream.myJID bare];
 
 		// Check if the 'from' JID of the message matches the current user's JID, indicating it's an outgoing message.
-        BOOL isOutgoing = [[message from].full isEqualToString:ownJid];
+        BOOL isOutgoing = [[message from].bare isEqualToString:ownJid];
 		
 		XMPPJID *messageJid;
 		if (isOutgoing)

--- a/Extensions/XEP-0136/XMPPMessageArchiving.m
+++ b/Extensions/XEP-0136/XMPPMessageArchiving.m
@@ -237,7 +237,7 @@
 		NSString *ownJid = [xmppStream.myJID bare];
 
 		// Check if the 'from' JID of the message matches the current user's JID, indicating it's an outgoing message.
-		isOutgoing = [[message from].full isEqualToString:ownJid];
+        BOOL isOutgoing = [[message from].full isEqualToString:ownJid];
 		
 		XMPPJID *messageJid;
 		if (isOutgoing)

--- a/XMPPFramework.podspec
+++ b/XMPPFramework.podspec
@@ -23,7 +23,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.default_subspec = 'default'
-  s.dependency 'Firebase/Crashlytics'
 
   s.subspec 'default' do |ss|
 	  ss.source_files = ['Core/**/*.{h,m}',

--- a/XMPPFramework.podspec
+++ b/XMPPFramework.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.default_subspec = 'default'
+  s.dependency 'Firebase/Crashlytics'
 
   s.subspec 'default' do |ss|
 	  ss.source_files = ['Core/**/*.{h,m}',


### PR DESCRIPTION
We are using MAM 2 but would not be able to process the messages since all incoming messages are tagged with isOutgoing = false even though the message originally came from ourself.
To solve that issue we instead infer the direction. 

```
public var mam = XMPPMessageArchiveManagement()

        let jid = _SOME JID_
  
        var fields: [DDXMLElement]? = nil
        let resultSet = XMPPResultSet(max: 100)
        mam.retrieveMessageArchive(withFields: fields, with: resultSet)
```

By using above we then process the necessary answer below:
```    
public func xmppStream(_ sender: XMPPStream, willReceive message: XMPPMessage) -> XMPPMessage? {
        // Check if the message has a MAM result
        if let xmppMessage = message.mamResult?.forwardedMessage {
           
            return xmppMessage
        }
        
        // If not a MAM message or some other error, just return the original message
        return message
    }
```

By doing above combined with the code allows the messages to be stored correctly.

We discussed a couple of developers if they could find use cases for setting the direction manually and we could not. 

