### PR TITLE
Fix for DDXMLNode XMLStringWithOptions crash - issue #105 and #113

### DIFF
--- a/Core/XMPPStream.m
+++ b/Core/XMPPStream.m
@@ -523,17 +523,18 @@ enum XMPPStreamConfig
 {
 	if (dispatch_get_specific(xmppQueueTag))
 	{
-		return myPresence;
+		XMPPPresence *myPresenceCopy = [myPresence copy];
+		return myPresenceCopy;
 	}
 	else
 	{
-		__block XMPPPresence *result;
+		__block XMPPPresence *myPresenceCopy;
 		
 		dispatch_sync(xmppQueue, ^{
-			result = self->myPresence;
+			myPresenceCopy = [self->myPresence copy];
 		});
 		
-		return result;
+		return myPresenceCopy;
 	}
 }
 
@@ -2455,14 +2456,16 @@ enum XMPPStreamConfig
 				}});
 			}
 			
-			if (modifiedPresence)
+			__block XMPPPresence *modifiedPresenceCopy = [modifiedPresence copy];
+
+			if (modifiedPresenceCopy)
 			{
 				dispatch_async(self->xmppQueue, ^{ @autoreleasepool {
 					
 					if (self->state == STATE_XMPP_CONNECTED) {
-						[self continueSendPresence:modifiedPresence withTag:tag];
+						[self continueSendPresence:modifiedPresenceCopy withTag:tag];
 					} else {
-						[self failToSendPresence:modifiedPresence];
+						[self failToSendPresence:modifiedPresenceCopy];
 					}
 				}});
 			}


### PR DESCRIPTION
This pull request fixes [Issue 105](https://github.com/robbiehanson/KissXML/issues/105) and [Issue 113](https://github.com/robbiehanson/KissXML/issues/113).

I work on the same product as Vlad from issue 105 and have produced a fix for the DDXMLNode XMLStringWithOptions crash. The fix was released this week and we've observed no new instances of the crash in our analytics since so we're confident it has fixed it given we had >16,000 crashes recorded by our analytics in the 4 weeks prior.

Here's a snippet from an example stack trace:
Thread 32 Crashed:
0   libxml2.2.dylib                     0x00000001b3a0f4b0 0x1b3989000 + 550064
1   libxml2.2.dylib                     0x00000001b3a0fec0 0x1b3989000 + 552640
2   libxml2.2.dylib                     0x00000001b3a0fd74 0x1b3989000 + 552308
3   libxml2.2.dylib                     0x00000001b3a0fc8c 0x1b3989000 + 552076
4   KissXML                             0x0000000106ddb2c4 -[DDXMLNode XMLStringWithOptions:] + 45764 (DDXMLNode.m:1171)
5   XMPPFramework                       0x00000001073581b0 -[XMPPStream continueSendPresence:withTag:] + 491952 (XMPPStream.m:2551)
6   XMPPFramework                       0x0000000107357f4c __35-[XMPPStream sendPresence:withTag:]_block_invoke_3 + 491340 (XMPPStream.m:0)
7   libdispatch.dylib                   0x000000019355d320 0x19355b000 + 8992
8   libdispatch.dylib                   0x000000019355eeac 0x19355b000 + 16044
9   libdispatch.dylib                   0x0000000193566534 0x19355b000 + 46388
10  libdispatch.dylib                   0x00000001935670a4 0x19355b000 + 49316
11  libdispatch.dylib                   0x0000000193571cdc 0x19355b000 + 93404
12  libsystem_pthread.dylib             0x00000001ebe18ddc 0x1ebe18000 + 3548
13  libsystem_pthread.dylib             0x00000001ebe18b7c 0x1ebe18000 + 2940

Thread 24:
0   libsystem_kernel.dylib              0x00000001cafd41dc 0x1cafd3000 + 4572
1   libdispatch.dylib                   0x000000019358281c 0x19355b000 + 161820
2   libdispatch.dylib                   0x000000019356e6f8 0x19355b000 + 79608
3   libdispatch.dylib                   0x000000019356e2c0 0x19355b000 + 78528
4   XMPPFramework                       0x0000000107351b68 -[XMPPStream myJID] + 465768 (XMPPStream.m:456)
5   XMPPFramework                       0x0000000107369bcc -[XMPPvCardAvatarModule xmppStream:willSendPresence:] + 564172 (XMPPvCardAvatarModule.m:188)
6   XMPPFramework                       0x0000000107357ee4 __35-[XMPPStream sendPresence:withTag:]_block_invoke_2 + 491236 (XMPPStream.m:2485)
7   libdispatch.dylib                   0x000000019355eeac 0x19355b000 + 16044
8   libdispatch.dylib                   0x000000019356e428 0x19355b000 + 78888
9   XMPPFramework                       0x0000000107357dd8 __35-[XMPPStream sendPresence:withTag:]_block_invoke + 490968 (XMPPStream.m:2488)
10  libdispatch.dylib                   0x000000019355d320 0x19355b000 + 8992
11  libdispatch.dylib                   0x000000019355eeac 0x19355b000 + 16044
12  libdispatch.dylib                   0x0000000193566534 0x19355b000 + 46388
13  libdispatch.dylib                   0x00000001935670a4 0x19355b000 + 49316
14  libdispatch.dylib                   0x0000000193571cdc 0x19355b000 + 93404
15  libsystem_pthread.dylib             0x00000001ebe18ddc 0x1ebe18000 + 3548
16  libsystem_pthread.dylib             0x00000001ebe18b7c 0x1ebe18000 + 2940

We never managed to reproduce the issue and we've taken copies in a couple of places to try to avoid memory being shared. Hence, we're not precisely sure which piece of code fixes the issue. However, we suspect that memory is being modified by one thread whilst being used on a second which is causing the crash. This is supported by the stack traces having identical code flows, with the crashing thread always calling [XMPPStream continueSendPresence:withTag:] and another calling [XMPPvCardAvatarModule xmppStream:willSendPresence:].